### PR TITLE
Apply card architecture to offline

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
         "@radix-ui/react-tooltip": "^1.1.2",
         "@tabler/icons-react": "^3.35.0",
         "@tanstack/react-router": "^1.133.32",
+        "clsx": "^2.1.1",
         "daisyui": "^5.0.0",
         "i18next": "^25.6.2",
         "i18next-browser-languagedetector": "^8.2.0",
@@ -587,6 +588,8 @@
     "ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
 
     "clone": ["clone@1.0.4", "", {}, "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="],
+
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 

--- a/docs/data-model-driven-card-architecture.md
+++ b/docs/data-model-driven-card-architecture.md
@@ -408,6 +408,10 @@ classDiagram
     localization maps; update cards and undo states.
   - Reshape `WalkPointOfInterest` and saved routes; ensure tags use registries
     and unit formatting covers all numerical values.
+- Status (6 Dec 2025): Offline suggestions/downloads now expose
+  localisation maps with SI sizes and relative timestamps; saved routes/POIs
+  resolve tags via registries and route metrics render through the unit
+  formatters.
 - **Phase 4: wizard & completion**
   - Move wizard route summary and generated stops to the shared route/stop
     schemas; delete entity strings from Fluent.

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@radix-ui/react-tooltip": "^1.1.2",
     "@tabler/icons-react": "^3.35.0",
     "@tanstack/react-router": "^1.133.32",
+    "clsx": "^2.1.1",
     "daisyui": "^5.0.0",
     "i18next": "^25.6.2",
     "i18next-browser-languagedetector": "^8.2.0",

--- a/src/app/components/button.tsx
+++ b/src/app/components/button.tsx
@@ -4,7 +4,7 @@ import { Slot } from "@radix-ui/react-slot";
 import type { ButtonHTMLAttributes } from "react";
 import { forwardRef } from "react";
 
-type ButtonVariant = "accent" | "ghost";
+type ButtonVariant = "accent" | "ghost" | "circle";
 type ButtonSize = "sm" | "md";
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -14,21 +14,35 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: ButtonVariant;
   /** Density of the padding and font size. */
   size?: ButtonSize;
+  /** Whether the button is in an active/pressed state (for toggle buttons). */
+  active?: boolean;
 }
 
 function joinClassNames(...tokens: Array<string | false | null | undefined>): string {
   return tokens.filter(Boolean).join(" ");
 }
 
-function resolveVariant(variant: ButtonVariant): string {
+function resolveVariant(variant: ButtonVariant, active?: boolean): string {
   if (variant === "ghost") {
     return "border border-base-content/20 bg-transparent text-base-content hover:bg-base-200/60";
+  }
+  if (variant === "circle") {
+    return active
+      ? "h-10 w-10 rounded-full border border-base-300/60 bg-accent text-base-900"
+      : "h-10 w-10 rounded-full border border-base-300/60 bg-base-200/70 text-base-content";
   }
   return "bg-accent text-base-900 hover:bg-accent/90";
 }
 
-function resolveSize(size: ButtonSize): string {
+function resolveSize(size: ButtonSize, variant: ButtonVariant): string {
+  if (variant === "circle") {
+    return ""; // Circle variant has fixed dimensions
+  }
   return size === "sm" ? "px-3 py-1.5 text-sm" : "px-4 py-2 text-base";
+}
+
+function resolveShape(variant: ButtonVariant): string {
+  return variant === "circle" ? "" : "rounded-xl";
 }
 
 /**
@@ -37,17 +51,21 @@ function resolveSize(size: ButtonSize): string {
  * @example
  * ```tsx
  * <Button variant="accent" size="sm">Download</Button>
+ * <Button variant="circle" active={isActive} aria-pressed={isActive}>
+ *   <Icon token="{icon.action.like}" />
+ * </Button>
  * ```
  */
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
-  { asChild = false, className, size = "md", variant = "accent", ...props },
+  { asChild = false, className, size = "md", variant = "accent", active, ...props },
   ref,
 ) {
   const Component = asChild ? Slot : "button";
   const classes = joinClassNames(
-    "inline-flex items-center justify-center gap-2 rounded-xl font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-base-100 disabled:cursor-not-allowed disabled:opacity-60",
-    resolveVariant(variant),
-    resolveSize(size),
+    "inline-flex items-center justify-center gap-2 font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-base-100 disabled:cursor-not-allowed disabled:opacity-60",
+    resolveShape(variant),
+    resolveVariant(variant, active),
+    resolveSize(size, variant),
     className,
   );
 

--- a/src/app/components/map/map-panel-constants.ts
+++ b/src/app/components/map/map-panel-constants.ts
@@ -1,4 +1,4 @@
 /** @file Shared constants for map panel components. */
 
 /** Tailwind class string for the draggable handle at the top of overlay panels. */
-export const STICKY_HANDLE_CLASS = "mx-auto block h-2 w-12 rounded-full bg-base-300/70";
+export const DRAGGABLE_HANDLE_CLASS = "mx-auto block h-2 w-12 rounded-full bg-base-300/70";

--- a/src/app/components/map/map-panel-constants.ts
+++ b/src/app/components/map/map-panel-constants.ts
@@ -1,0 +1,4 @@
+/** @file Shared constants for map panel components. */
+
+/** Tailwind class string for the draggable handle at the top of overlay panels. */
+export const STICKY_HANDLE_CLASS = "mx-auto block h-2 w-12 rounded-full bg-base-300/70";

--- a/src/app/components/map/map-route-stat.tsx
+++ b/src/app/components/map/map-route-stat.tsx
@@ -10,7 +10,7 @@ export type MapRouteStatProps = {
 export function MapRouteStat({ label, value }: MapRouteStatProps): JSX.Element {
   return (
     <span className="map-route__stat">
-      <p className="map-route__stat-value">{value}</p>
+      <span className="map-route__stat-value">{value}</span>
       {label}
     </span>
   );

--- a/src/app/components/map/map-route-stat.tsx
+++ b/src/app/components/map/map-route-stat.tsx
@@ -1,0 +1,17 @@
+/** @file Reusable stat display for map route metrics (distance, duration, stops). */
+
+import type { JSX } from "react";
+
+export type MapRouteStatProps = {
+  readonly label: string;
+  readonly value: string | number;
+};
+
+export function MapRouteStat({ label, value }: MapRouteStatProps): JSX.Element {
+  return (
+    <span className="map-route__stat">
+      <p className="map-route__stat-value">{value}</p>
+      {label}
+    </span>
+  );
+}

--- a/src/app/components/map/map-route-stat.tsx
+++ b/src/app/components/map/map-route-stat.tsx
@@ -16,6 +16,9 @@ export type MapRouteStatProps = {
 /**
  * Displays a single route statistic with a prominent value and label.
  *
+ * Numeric values are rendered inside a semantic `<data>` element with
+ * a machine-readable `value` attribute; string values use a `<span>`.
+ *
  * @example
  * // String value with unit
  * <MapRouteStat label="Distance" value="4.2 km" />
@@ -26,18 +29,24 @@ export type MapRouteStatProps = {
  * // </span>
  *
  * @example
- * // Numeric value
+ * // Numeric value renders inside <data>
  * <MapRouteStat label="Stops" value={5} />
  * // Renders:
  * // <span class="map-route__stat">
- * //   <span class="map-route__stat-value">5</span>
+ * //   <data class="map-route__stat-value" value="5">5</data>
  * //   Stops
  * // </span>
  */
 export function MapRouteStat({ label, value }: MapRouteStatProps): JSX.Element {
   return (
     <span className="map-route__stat">
-      <span className="map-route__stat-value">{value}</span>
+      {typeof value === "number" ? (
+        <data className="map-route__stat-value" value={String(value)}>
+          {value}
+        </data>
+      ) : (
+        <span className="map-route__stat-value">{value}</span>
+      )}
       {label}
     </span>
   );

--- a/src/app/components/map/map-route-stat.tsx
+++ b/src/app/components/map/map-route-stat.tsx
@@ -2,11 +2,38 @@
 
 import type { JSX } from "react";
 
+/**
+ * Props for the MapRouteStat component.
+ *
+ * @property label - Descriptive text displayed below the value (e.g., "Distance").
+ * @property value - Numeric or string metric to display prominently.
+ */
 export type MapRouteStatProps = {
   readonly label: string;
   readonly value: string | number;
 };
 
+/**
+ * Displays a single route statistic with a prominent value and label.
+ *
+ * @example
+ * // String value with unit
+ * <MapRouteStat label="Distance" value="4.2 km" />
+ * // Renders:
+ * // <span class="map-route__stat">
+ * //   <span class="map-route__stat-value">4.2 km</span>
+ * //   Distance
+ * // </span>
+ *
+ * @example
+ * // Numeric value
+ * <MapRouteStat label="Stops" value={5} />
+ * // Renders:
+ * // <span class="map-route__stat">
+ * //   <span class="map-route__stat-value">5</span>
+ * //   Stops
+ * // </span>
+ */
 export function MapRouteStat({ label, value }: MapRouteStatProps): JSX.Element {
   return (
     <span className="map-route__stat">

--- a/src/app/components/point-of-interest-list.tsx
+++ b/src/app/components/point-of-interest-list.tsx
@@ -1,7 +1,7 @@
 /** @file Shared list rendering points of interest with Radix dialog sheets. */
 
 import * as Dialog from "@radix-ui/react-dialog";
-import type { JSX } from "react";
+import { type JSX, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { WalkPointOfInterest } from "../data/map";
@@ -177,10 +177,14 @@ export function PointOfInterestList({ points }: PointOfInterestListProps): JSX.E
   const highlightPois = mapStore?.actions.highlightPois;
   const { t, i18n } = useTranslation();
   const highlightBadgeLabel = t("poi-highlight-label", { defaultValue: "Highlight" });
-  const ratingFormatter = new Intl.NumberFormat(i18n.language, {
-    minimumFractionDigits: 1,
-    maximumFractionDigits: 1,
-  });
+  const ratingFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat(i18n.language, {
+        minimumFractionDigits: 1,
+        maximumFractionDigits: 1,
+      }),
+    [i18n.language],
+  );
 
   return (
     <div className="space-y-3">

--- a/src/app/components/point-of-interest-list.tsx
+++ b/src/app/components/point-of-interest-list.tsx
@@ -10,6 +10,164 @@ import { pickLocalization } from "../domain/entities/localization";
 import { useOptionalMapStore } from "../features/map/map-state";
 import { Icon } from "./icon";
 
+interface POIPresentation {
+  localization: ReturnType<typeof pickLocalization>;
+  categoryDescriptor?: ReturnType<typeof getTagDescriptor>;
+  categoryLabel: string;
+  tagDescriptors: NonNullable<ReturnType<typeof getTagDescriptor>>[];
+  formattedRating?: string | undefined;
+  openHoursCopy: string | null;
+}
+
+interface PointOfInterestItemProps {
+  poi: WalkPointOfInterest;
+  presentation: POIPresentation;
+  highlightPois?: ((poiIds: readonly string[]) => void) | undefined;
+  highlightBadgeLabel: string;
+  t: ReturnType<typeof useTranslation>["t"];
+}
+
+const preparePOIPresentation = (
+  poi: WalkPointOfInterest,
+  language: string,
+  t: ReturnType<typeof useTranslation>["t"],
+  ratingFormatter: Intl.NumberFormat,
+): POIPresentation => {
+  const localization = pickLocalization(poi.localizations, language);
+  const categoryDescriptor = getTagDescriptor(poi.categoryId, language);
+  const categoryLabel = categoryDescriptor?.localization.name ?? localization.name;
+  const tagDescriptors =
+    poi.tagIds
+      .map((tagId) => getTagDescriptor(tagId, language))
+      .filter((descriptor): descriptor is NonNullable<typeof descriptor> => Boolean(descriptor)) ??
+    [];
+  const formattedRating =
+    typeof poi.rating === "number" ? ratingFormatter.format(poi.rating) : undefined;
+  const openHoursCopy = poi.openHours
+    ? t("poi-open-hours", {
+        opensAt: poi.openHours.opensAt,
+        closesAt: poi.openHours.closesAt,
+        defaultValue: `${poi.openHours.opensAt}–${poi.openHours.closesAt}`,
+      })
+    : null;
+
+  return {
+    localization,
+    categoryDescriptor,
+    categoryLabel,
+    tagDescriptors,
+    formattedRating,
+    openHoursCopy,
+  };
+};
+
+const PointOfInterestItem = ({
+  poi,
+  presentation,
+  highlightPois,
+  highlightBadgeLabel,
+  t,
+}: PointOfInterestItemProps): JSX.Element => {
+  const {
+    localization,
+    categoryDescriptor,
+    categoryLabel,
+    tagDescriptors,
+    formattedRating,
+    openHoursCopy,
+  } = presentation;
+
+  const handleHighlight = (ids: string[]) => highlightPois?.(ids);
+
+  return (
+    <Dialog.Root key={poi.id}>
+      <Dialog.Trigger asChild>
+        <button
+          type="button"
+          className="poi-list__item"
+          onMouseEnter={() => handleHighlight([poi.id])}
+          onFocus={() => handleHighlight([poi.id])}
+          onMouseLeave={() => handleHighlight([])}
+          onBlur={() => handleHighlight([])}
+        >
+          <div className="poi-list__summary">
+            <div>
+              <h3 className="text-base font-semibold text-base-content">{localization.name}</h3>
+              <p className="mt-1 text-sm text-base-content/70">{localization.description}</p>
+            </div>
+            {formattedRating ? (
+              <span className="rating-indicator rating-indicator--strong">
+                <Icon token="{icon.object.star}" aria-hidden className="h-4 w-4" />
+                {formattedRating}
+              </span>
+            ) : null}
+          </div>
+          <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-accent">
+            <span className="poi-highlight">
+              <Icon
+                token={categoryDescriptor?.iconToken ?? "{icon.object.marker}"}
+                className={`h-4 w-4 ${categoryDescriptor?.accentClass ?? ""}`.trim()}
+                label={categoryLabel}
+              />
+              <span aria-hidden>{highlightBadgeLabel}</span>
+            </span>
+            {tagDescriptors.map((tag) => (
+              <span
+                key={tag.id}
+                className="rounded-full border border-base-300/60 bg-base-100 px-2 py-0.5 text-base-content/70"
+              >
+                {tag.localization.name}
+              </span>
+            ))}
+          </div>
+        </button>
+      </Dialog.Trigger>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/60" />
+        <Dialog.Content className="fixed inset-0 z-50 flex items-center justify-center p-4">
+          <div className="poi-sheet">
+            <div className="poi-list__summary">
+              <div>
+                <Dialog.Title className="text-lg font-semibold text-base-content">
+                  {localization.name}
+                </Dialog.Title>
+                <Dialog.Description className="mt-1 text-sm text-base-content/70">
+                  {localization.description}
+                </Dialog.Description>
+              </div>
+              <Dialog.Close asChild>
+                <button type="button" className="btn btn-ghost btn-sm">
+                  {t("action-close", { defaultValue: "Close" })}
+                </button>
+              </Dialog.Close>
+            </div>
+            <div className="mt-4 space-y-2 text-sm text-base-content/70">
+              {tagDescriptors.length > 0 ? (
+                <div className="flex flex-wrap gap-2">
+                  {tagDescriptors.map((tag) => (
+                    <span
+                      key={tag.id}
+                      className="rounded-full border border-base-300/60 bg-base-200/70 px-3 py-1 text-xs"
+                    >
+                      {tag.localization.name}
+                    </span>
+                  ))}
+                </div>
+              ) : null}
+              {openHoursCopy ? (
+                <p className="flex items-center gap-2 text-xs text-base-content/60">
+                  <Icon token="{icon.object.duration}" aria-hidden className="h-4 w-4" />
+                  {openHoursCopy}
+                </p>
+              ) : null}
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+};
+
 export interface PointOfInterestListProps {
   points: WalkPointOfInterest[];
 }
@@ -27,113 +185,16 @@ export function PointOfInterestList({ points }: PointOfInterestListProps): JSX.E
   return (
     <div className="space-y-3">
       {points.map((poi) => {
-        const localization = pickLocalization(poi.localizations, i18n.language);
-        const categoryDescriptor = getTagDescriptor(poi.categoryId, i18n.language);
-        const categoryLabel = categoryDescriptor?.localization.name ?? localization.name;
-        const tagDescriptors =
-          poi.tagIds
-            .map((tagId) => getTagDescriptor(tagId, i18n.language))
-            .filter((descriptor): descriptor is NonNullable<typeof descriptor> =>
-              Boolean(descriptor),
-            ) ?? [];
-        const formattedRating =
-          typeof poi.rating === "number" ? ratingFormatter.format(poi.rating) : undefined;
-        const openHoursCopy = poi.openHours
-          ? t("poi-open-hours", {
-              opensAt: poi.openHours.opensAt,
-              closesAt: poi.openHours.closesAt,
-              defaultValue: `${poi.openHours.opensAt}–${poi.openHours.closesAt}`,
-            })
-          : null;
-
+        const presentation = preparePOIPresentation(poi, i18n.language, t, ratingFormatter);
         return (
-          <Dialog.Root key={poi.id}>
-            <Dialog.Trigger asChild>
-              <button
-                type="button"
-                className="poi-list__item"
-                onMouseEnter={() => highlightPois?.([poi.id])}
-                onFocus={() => highlightPois?.([poi.id])}
-                onMouseLeave={() => highlightPois?.([])}
-                onBlur={() => highlightPois?.([])}
-              >
-                <div className="poi-list__summary">
-                  <div>
-                    <h3 className="text-base font-semibold text-base-content">
-                      {localization.name}
-                    </h3>
-                    <p className="mt-1 text-sm text-base-content/70">{localization.description}</p>
-                  </div>
-                  {formattedRating ? (
-                    <span className="rating-indicator rating-indicator--strong">
-                      <Icon token="{icon.object.star}" aria-hidden className="h-4 w-4" />
-                      {formattedRating}
-                    </span>
-                  ) : null}
-                </div>
-                <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-accent">
-                  <span className="poi-highlight">
-                    <Icon
-                      token={categoryDescriptor?.iconToken ?? "{icon.object.marker}"}
-                      className={`h-4 w-4 ${categoryDescriptor?.accentClass ?? ""}`.trim()}
-                      label={categoryLabel}
-                    />
-                    <span aria-hidden>{highlightBadgeLabel}</span>
-                  </span>
-                  {tagDescriptors.map((tag) => (
-                    <span
-                      key={tag.id}
-                      className="rounded-full border border-base-300/60 bg-base-100 px-2 py-0.5 text-base-content/70"
-                    >
-                      {tag.localization.name}
-                    </span>
-                  ))}
-                </div>
-              </button>
-            </Dialog.Trigger>
-            <Dialog.Portal>
-              <Dialog.Overlay className="fixed inset-0 bg-black/60" />
-              <Dialog.Content className="fixed inset-0 z-50 flex items-center justify-center p-4">
-                <div className="poi-sheet">
-                  <div className="poi-list__summary">
-                    <div>
-                      <Dialog.Title className="text-lg font-semibold text-base-content">
-                        {localization.name}
-                      </Dialog.Title>
-                      <Dialog.Description className="mt-1 text-sm text-base-content/70">
-                        {localization.description}
-                      </Dialog.Description>
-                    </div>
-                    <Dialog.Close asChild>
-                      <button type="button" className="btn btn-ghost btn-sm">
-                        {t("action-close", { defaultValue: "Close" })}
-                      </button>
-                    </Dialog.Close>
-                  </div>
-                  <div className="mt-4 space-y-2 text-sm text-base-content/70">
-                    {tagDescriptors.length > 0 ? (
-                      <div className="flex flex-wrap gap-2">
-                        {tagDescriptors.map((tag) => (
-                          <span
-                            key={tag.id}
-                            className="rounded-full border border-base-300/60 bg-base-200/70 px-3 py-1 text-xs"
-                          >
-                            {tag.localization.name}
-                          </span>
-                        ))}
-                      </div>
-                    ) : null}
-                    {openHoursCopy ? (
-                      <p className="flex items-center gap-2 text-xs text-base-content/60">
-                        <Icon token="{icon.object.duration}" aria-hidden className="h-4 w-4" />
-                        {openHoursCopy}
-                      </p>
-                    ) : null}
-                  </div>
-                </div>
-              </Dialog.Content>
-            </Dialog.Portal>
-          </Dialog.Root>
+          <PointOfInterestItem
+            key={poi.id}
+            poi={poi}
+            presentation={presentation}
+            highlightPois={highlightPois}
+            highlightBadgeLabel={highlightBadgeLabel}
+            t={t}
+          />
         );
       })}
     </div>

--- a/src/app/components/point-of-interest-list.tsx
+++ b/src/app/components/point-of-interest-list.tsx
@@ -38,11 +38,9 @@ const preparePOIPresentation = (
   const localization = pickLocalization(poi.localizations, language);
   const categoryDescriptor = getTagDescriptor(poi.categoryId, language);
   const categoryLabel = categoryDescriptor?.localization.name ?? localization.name;
-  const tagDescriptors =
-    poi.tagIds
-      .map((tagId) => getTagDescriptor(tagId, language))
-      .filter((descriptor): descriptor is NonNullable<typeof descriptor> => Boolean(descriptor)) ??
-    [];
+  const tagDescriptors = poi.tagIds
+    .map((tagId) => getTagDescriptor(tagId, language))
+    .filter((descriptor): descriptor is NonNullable<typeof descriptor> => Boolean(descriptor));
   const formattedRating =
     typeof poi.rating === "number" ? ratingFormatter.format(poi.rating) : undefined;
   const openHoursCopy = poi.openHours
@@ -79,7 +77,7 @@ const PointOfInterestItem = ({
     openHoursCopy,
   } = presentation;
 
-  const handleHighlight = (ids: string[]) => highlightPois?.(ids);
+  const handleHighlight = (ids: readonly string[]) => highlightPois?.(ids);
 
   return (
     <Dialog.Root>

--- a/src/app/components/point-of-interest-list.tsx
+++ b/src/app/components/point-of-interest-list.tsx
@@ -171,7 +171,7 @@ const PointOfInterestItem = ({
 };
 
 export interface PointOfInterestListProps {
-  points: WalkPointOfInterest[];
+  readonly points: readonly WalkPointOfInterest[];
 }
 
 export function PointOfInterestList({ points }: PointOfInterestListProps): JSX.Element {

--- a/src/app/components/point-of-interest-list.tsx
+++ b/src/app/components/point-of-interest-list.tsx
@@ -1,21 +1,22 @@
 /** @file Shared list rendering points of interest with Radix dialog sheets. */
 
 import * as Dialog from "@radix-ui/react-dialog";
+import type { TFunction } from "i18next";
 import { type JSX, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { WalkPointOfInterest } from "../data/map";
-import { getTagDescriptor } from "../data/registries/tags";
-import { pickLocalization } from "../domain/entities/localization";
+import { getTagDescriptor, type ResolvedTagDescriptor } from "../data/registries/tags";
+import { type LocalizedStringSet, pickLocalization } from "../domain/entities/localization";
 import { useOptionalMapStore } from "../features/map/map-state";
 import { Icon } from "./icon";
 
 interface POIPresentation {
-  localization: ReturnType<typeof pickLocalization>;
-  categoryDescriptor?: ReturnType<typeof getTagDescriptor>;
+  localization: LocalizedStringSet;
+  categoryDescriptor: ResolvedTagDescriptor | undefined;
   categoryLabel: string;
-  tagDescriptors: NonNullable<ReturnType<typeof getTagDescriptor>>[];
-  formattedRating?: string | undefined;
+  tagDescriptors: ResolvedTagDescriptor[];
+  formattedRating: string | undefined;
   openHoursCopy: string | null;
 }
 
@@ -24,13 +25,13 @@ interface PointOfInterestItemProps {
   presentation: POIPresentation;
   highlightPois?: ((poiIds: readonly string[]) => void) | undefined;
   highlightBadgeLabel: string;
-  t: ReturnType<typeof useTranslation>["t"];
+  t: TFunction;
 }
 
 const preparePOIPresentation = (
   poi: WalkPointOfInterest,
   language: string,
-  t: ReturnType<typeof useTranslation>["t"],
+  t: TFunction,
   ratingFormatter: Intl.NumberFormat,
 ): POIPresentation => {
   const localization = pickLocalization(poi.localizations, language);

--- a/src/app/components/point-of-interest-list.tsx
+++ b/src/app/components/point-of-interest-list.tsx
@@ -9,6 +9,7 @@ import type { WalkPointOfInterest } from "../data/map";
 import { getTagDescriptor, type ResolvedTagDescriptor } from "../data/registries/tags";
 import { type LocalizedStringSet, pickLocalization } from "../domain/entities/localization";
 import { useOptionalMapStore } from "../features/map/map-state";
+import { Button } from "./button";
 import { Icon } from "./icon";
 
 interface POIPresentation {
@@ -81,7 +82,7 @@ const PointOfInterestItem = ({
   const handleHighlight = (ids: string[]) => highlightPois?.(ids);
 
   return (
-    <Dialog.Root key={poi.id}>
+    <Dialog.Root>
       <Dialog.Trigger asChild>
         <button
           type="button"
@@ -137,9 +138,9 @@ const PointOfInterestItem = ({
                 </Dialog.Description>
               </div>
               <Dialog.Close asChild>
-                <button type="button" className="btn btn-ghost btn-sm">
+                <Button variant="ghost" size="sm">
                   {t("action-close", { defaultValue: "Close" })}
-                </button>
+                </Button>
               </Dialog.Close>
             </div>
             <div className="mt-4 space-y-2 text-sm text-base-content/70">

--- a/src/app/components/point-of-interest-list.tsx
+++ b/src/app/components/point-of-interest-list.tsx
@@ -93,7 +93,9 @@ const PointOfInterestItem = ({
           <div className="poi-list__summary">
             <div>
               <h3 className="text-base font-semibold text-base-content">{localization.name}</h3>
-              <p className="mt-1 text-sm text-base-content/70">{localization.description}</p>
+              {localization.description ? (
+                <p className="mt-1 text-sm text-base-content/70">{localization.description}</p>
+              ) : null}
             </div>
             {formattedRating ? (
               <span className="rating-indicator rating-indicator--strong">
@@ -131,9 +133,11 @@ const PointOfInterestItem = ({
                 <Dialog.Title className="text-lg font-semibold text-base-content">
                   {localization.name}
                 </Dialog.Title>
-                <Dialog.Description className="mt-1 text-sm text-base-content/70">
-                  {localization.description}
-                </Dialog.Description>
+                {localization.description ? (
+                  <Dialog.Description className="mt-1 text-sm text-base-content/70">
+                    {localization.description}
+                  </Dialog.Description>
+                ) : null}
               </div>
               <Dialog.Close asChild>
                 <Button variant="ghost" size="sm">

--- a/src/app/config/route-urls.ts
+++ b/src/app/config/route-urls.ts
@@ -1,0 +1,16 @@
+/** @file URL configuration for route sharing and deep links. */
+
+/**
+ * Base URL for public route sharing links.
+ *
+ * @example
+ * getRouteShareUrl("route-123") // => "https://wildside.app/routes/route-123"
+ */
+export const ROUTE_SHARE_BASE_URL = "https://wildside.app/routes";
+
+/**
+ * Constructs a shareable URL for a given route ID.
+ */
+export function getRouteShareUrl(routeId: string): string {
+  return `${ROUTE_SHARE_BASE_URL}/${routeId}`;
+}

--- a/src/app/config/route-urls.ts
+++ b/src/app/config/route-urls.ts
@@ -10,6 +10,12 @@ export const ROUTE_SHARE_BASE_URL = "https://wildside.app/routes";
 
 /**
  * Constructs a shareable URL for a given route ID.
+ *
+ * Route IDs use kebab-case and require no URL-encoding.
+ *
+ * @example
+ * getRouteShareUrl("harbour-lights") // => "https://wildside.app/routes/harbour-lights"
+ * getRouteShareUrl("coffee-culture-loop") // => "https://wildside.app/routes/coffee-culture-loop"
  */
 export function getRouteShareUrl(routeId: string): string {
   return `${ROUTE_SHARE_BASE_URL}/${routeId}`;

--- a/src/app/data/map.ts
+++ b/src/app/data/map.ts
@@ -1,6 +1,10 @@
 /** @file Fixture data powering Stage 2 map experiences. */
 
+import type { EntityLocalizations, ImageAsset } from "../domain/entities/localization";
 import { metresFromMiles, secondsFromMinutes } from "../units/unit-format";
+import { fillLocalizations, localizeAcrossLocales } from "./fixture-localization";
+import type { DifficultyId } from "./registries/difficulties";
+import type { TagId } from "./registries/tags";
 
 export interface QuickWalkConfig {
   backgroundImageUrl: string;
@@ -12,35 +16,34 @@ export interface QuickWalkConfig {
 
 export interface WalkPointOfInterest {
   id: string;
-  name: string;
-  description: string;
-  tags: string[];
+  localizations: EntityLocalizations;
+  categoryId: TagId;
+  tagIds: TagId[];
   rating?: number;
-  imageUrl?: string;
-  openHours?: string;
-  categoryIconToken: string;
-  categoryColorClass: string;
-  /** Localised description of the category icon for assistive tech. */
-  categoryLabel: string;
+  image?: ImageAsset;
+  openHours?: { opensAt: string; closesAt: string };
+}
+
+export interface RouteNote {
+  id: string;
+  localizations: EntityLocalizations;
 }
 
 export interface WalkRouteSummary {
   id: string;
-  title: string;
+  localizations: EntityLocalizations;
+  coverImage: ImageAsset;
+  mapImage: ImageAsset;
   distanceMetres: number;
   durationSeconds: number;
   stopsCount: number;
-  difficulty: string;
+  difficultyId: DifficultyId;
   rating: number;
   saves: number;
-  updatedAgo: string;
-  coverImageUrl: string;
-  mapBackgroundUrl: string;
-  mapAlt: string;
-  description: string;
-  highlights: string[];
+  lastUpdatedAt: string;
+  highlightTagIds: TagId[];
   pointsOfInterest: WalkPointOfInterest[];
-  notes: string[];
+  notes: RouteNote[];
 }
 
 export const quickWalkConfig: QuickWalkConfig = {
@@ -58,94 +61,236 @@ export const quickWalkConfig: QuickWalkConfig = {
 
 export const waterfrontDiscoveryRoute: WalkRouteSummary = {
   id: "waterfront-discovery",
-  title: "Waterfront Discovery Walk",
+  localizations: fillLocalizations(
+    localizeAcrossLocales(
+      {
+        name: "Waterfront Discovery Walk",
+        description:
+          "A relaxed harbour-side loop that blends coffee stops, tranquil parks, and vibrant street art with sweeping skyline views.",
+      },
+      {
+        es: {
+          name: "Paseo de descubrimiento del puerto",
+          description:
+            "Un circuito relajado junto al puerto con cafeterías, parques tranquilos y arte urbano vibrante con vistas al horizonte.",
+        },
+      },
+    ),
+    "en-GB",
+    "route: waterfront-discovery",
+  ),
+  coverImage: {
+    url: "https://storage.googleapis.com/uxpilot-auth.appspot.com/26681e8543-4aea58234426af19b1c5.png",
+    alt: "City riverfront with a pedestrian boardwalk at dusk.",
+  },
+  mapImage: {
+    url: "https://storage.googleapis.com/uxpilot-auth.appspot.com/1408b2a1ec-80b4836a18f461653773.png",
+    alt: "Highlighted walking route weaving through parks, cafes, and waterfront landmarks",
+  },
   distanceMetres: metresFromMiles(2.3),
   durationSeconds: secondsFromMinutes(45),
   stopsCount: 6,
-  difficulty: "Easy",
+  difficultyId: "easy",
   rating: 4.8,
   saves: 127,
-  updatedAgo: "2 days ago",
-  coverImageUrl:
-    "https://storage.googleapis.com/uxpilot-auth.appspot.com/26681e8543-4aea58234426af19b1c5.png",
-  mapBackgroundUrl:
-    "https://storage.googleapis.com/uxpilot-auth.appspot.com/1408b2a1ec-80b4836a18f461653773.png",
-  mapAlt: "Highlighted walking route weaving through parks, cafes, and waterfront landmarks",
-  description:
-    "A relaxed harbour-side loop that blends coffee stops, tranquil parks, and vibrant street art with sweeping skyline views.",
-  highlights: ["Sunrise ready", "Pet friendly", "Café stops"],
+  lastUpdatedAt: "2025-12-03T18:00:00Z",
+  highlightTagIds: ["views", "coffee", "instagram"],
   pointsOfInterest: [
     {
       id: "blue-bottle-coffee",
-      name: "Blue Bottle Coffee",
-      description: "Pour-over specialists in a cosy warehouse setting.",
-      tags: ["Coffee", "Local favourite"],
+      localizations: fillLocalizations(
+        localizeAcrossLocales(
+          {
+            name: "Blue Bottle Coffee",
+            description: "Pour-over specialists in a cosy warehouse setting.",
+          },
+          {
+            es: {
+              name: "Blue Bottle Coffee",
+              description: "Especialistas en pour-over en un acogedor almacén.",
+            },
+          },
+        ),
+        "en-GB",
+        "poi: blue-bottle-coffee",
+      ),
+      categoryId: "coffee",
+      tagIds: ["coffee", "local"],
       rating: 4.7,
-      categoryIconToken: "{icon.category.food}",
-      categoryColorClass: "text-amber-400",
-      categoryLabel: "Coffee and pastries",
-      openHours: "7:00 AM – 8:00 PM",
+      image: {
+        url: "https://storage.googleapis.com/uxpilot-auth.appspot.com/03fdb8eff5-0706dc4eec4e2208ca2d.png",
+        alt: "Barista pouring coffee beside pastries.",
+      },
+      openHours: { opensAt: "07:00", closesAt: "20:00" },
     },
     {
       id: "harbor-pier",
-      name: "Harbour Pier Lookout",
-      description: "Panoramic harbour vistas – perfect for golden hour snaps.",
-      tags: ["Views", "Photos", "Free"],
+      localizations: fillLocalizations(
+        localizeAcrossLocales(
+          {
+            name: "Harbour Pier Lookout",
+            description: "Panoramic harbour vistas – perfect for golden hour snaps.",
+          },
+          {
+            es: {
+              name: "Mirador del muelle",
+              description: "Vistas panorámicas del puerto, perfectas para la hora dorada.",
+            },
+          },
+        ),
+        "en-GB",
+        "poi: harbor-pier",
+      ),
+      categoryId: "views",
+      tagIds: ["views", "photos", "free"],
       rating: 4.9,
-      categoryIconToken: "{icon.category.photography}",
-      categoryColorClass: "text-sky-400",
-      categoryLabel: "Scenic viewpoint",
-      openHours: "24/7",
+      image: {
+        url: "https://storage.googleapis.com/uxpilot-auth.appspot.com/7c8c56a54b-101578a06001bb190271.png",
+        alt: "Pier overlooking a city skyline at sunset.",
+      },
+      openHours: { opensAt: "00:00", closesAt: "23:59" },
     },
     {
       id: "mural-alley",
-      name: "Mural Alley",
-      description: "Rotating gallery of local street art tucked behind the main drag.",
-      tags: ["Art", "Instagram"],
+      localizations: fillLocalizations(
+        localizeAcrossLocales(
+          {
+            name: "Mural Alley",
+            description: "Rotating gallery of local street art tucked behind the main drag.",
+          },
+          {
+            es: {
+              name: "Callejón de murales",
+              description: "Galería cambiante de arte urbano local tras la calle principal.",
+            },
+          },
+        ),
+        "en-GB",
+        "poi: mural-alley",
+      ),
+      categoryId: "instagram",
+      tagIds: ["instagram", "photos", "free"],
       rating: 4.4,
-      categoryIconToken: "{icon.category.art}",
-      categoryColorClass: "text-purple-400",
-      categoryLabel: "Street art highlight",
-      openHours: "10:00 AM – 7:00 PM",
+      image: {
+        url: "https://storage.googleapis.com/uxpilot-auth.appspot.com/ad4258f4ad-817a02de971280a8ef8b.png",
+        alt: "Colourful street art mural in a narrow alley.",
+      },
+      openHours: { opensAt: "10:00", closesAt: "19:00" },
     },
     {
       id: "riverside-garden",
-      name: "Riverside Garden",
-      description: "Lush boardwalk planted with native flora and shaded seating.",
-      tags: ["Nature", "Rest stop"],
+      localizations: fillLocalizations(
+        localizeAcrossLocales(
+          {
+            name: "Riverside Garden",
+            description: "Lush boardwalk planted with native flora and shaded seating.",
+          },
+          {
+            es: {
+              name: "Jardín ribereño",
+              description: "Pasarela con vegetación autóctona y zonas de sombra.",
+            },
+          },
+        ),
+        "en-GB",
+        "poi: riverside-garden",
+      ),
+      categoryId: "nature",
+      tagIds: ["nature", "rest-stop"],
       rating: 4.6,
-      categoryIconToken: "{icon.category.nature}",
-      categoryColorClass: "text-emerald-400",
-      categoryLabel: "Nature stop",
-      openHours: "6:00 AM – 9:00 PM",
+      image: {
+        url: "https://storage.googleapis.com/uxpilot-auth.appspot.com/26681e8543-4aea58234426af19b1c5.png",
+        alt: "Boardwalk framed by greenery beside the water.",
+      },
+      openHours: { opensAt: "06:00", closesAt: "21:00" },
     },
     {
       id: "lighthouse-market",
-      name: "Lighthouse Market",
-      description: "Weekly stalls with small batch bakers, makers, and live music.",
-      tags: ["Market", "Local"],
+      localizations: fillLocalizations(
+        localizeAcrossLocales(
+          {
+            name: "Lighthouse Market",
+            description: "Weekly stalls with small batch bakers, makers, and live music.",
+          },
+          {
+            es: {
+              name: "Mercado del faro",
+              description: "Puestos semanales de panaderos artesanos, artesanos y música en vivo.",
+            },
+          },
+        ),
+        "en-GB",
+        "poi: lighthouse-market",
+      ),
+      categoryId: "market",
+      tagIds: ["market", "local"],
       rating: 4.5,
-      categoryIconToken: "{icon.category.shops}",
-      categoryColorClass: "text-orange-400",
-      categoryLabel: "Market stalls",
-      openHours: "Saturdays 8:00 AM – 2:00 PM",
+      image: {
+        url: "https://storage.googleapis.com/uxpilot-auth.appspot.com/26681e8543-4aea58234426af19b1c5.png",
+        alt: "Outdoor market with string lights and crowd.",
+      },
+      openHours: { opensAt: "08:00", closesAt: "14:00" },
     },
     {
       id: "skyline-bridge",
-      name: "Skyline Bridge",
-      description: "Suspended skywalk linking two cultural precincts over the water.",
-      tags: ["Architecture", "Landmark"],
+      localizations: fillLocalizations(
+        localizeAcrossLocales(
+          {
+            name: "Skyline Bridge",
+            description: "Suspended skywalk linking two cultural precincts over the water.",
+          },
+          {
+            es: {
+              name: "Puente Skyline",
+              description:
+                "Pasarela suspendida que conecta dos distritos culturales sobre el agua.",
+            },
+          },
+        ),
+        "en-GB",
+        "poi: skyline-bridge",
+      ),
+      categoryId: "landmark",
+      tagIds: ["architecture", "landmark", "views"],
       rating: 4.8,
-      categoryIconToken: "{icon.category.landmarks}",
-      categoryColorClass: "text-cyan-300",
-      categoryLabel: "Landmark bridge",
-      openHours: "8:00 AM – 10:00 PM",
+      image: {
+        url: "https://storage.googleapis.com/uxpilot-auth.appspot.com/1408b2a1ec-80b4836a18f461653773.png",
+        alt: "Pedestrian bridge with skyline backdrop.",
+      },
+      openHours: { opensAt: "08:00", closesAt: "22:00" },
     },
   ],
   notes: [
-    "Allow extra time at the harbour lookout – it becomes busy around sunset.",
-    "Keep the boardwalk section for last if you plan to record timelapses.",
-    "Weekend market opening times vary; check the community board for pop-up vendors.",
+    {
+      id: "sunset",
+      localizations: fillLocalizations(
+        localizeAcrossLocales({
+          name: "Allow extra time at the harbour lookout – it becomes busy around sunset.",
+        }),
+        "en-GB",
+        "route-note: sunset",
+      ),
+    },
+    {
+      id: "timelapse",
+      localizations: fillLocalizations(
+        localizeAcrossLocales({
+          name: "Keep the boardwalk section for last if you plan to record timelapses.",
+        }),
+        "en-GB",
+        "route-note: timelapse",
+      ),
+    },
+    {
+      id: "markets",
+      localizations: fillLocalizations(
+        localizeAcrossLocales({
+          name: "Weekend market times vary; check the community board for pop-up vendors.",
+        }),
+        "en-GB",
+        "route-note: markets",
+      ),
+    },
   ],
 };
 

--- a/src/app/data/map.ts
+++ b/src/app/data/map.ts
@@ -15,18 +15,18 @@ export interface QuickWalkConfig {
 }
 
 export interface WalkPointOfInterest {
-  id: string;
-  localizations: EntityLocalizations;
-  categoryId: TagId;
-  tagIds: TagId[];
-  rating?: number;
-  image?: ImageAsset;
-  openHours?: { opensAt: string; closesAt: string };
+  readonly id: string;
+  readonly localizations: EntityLocalizations;
+  readonly categoryId: TagId;
+  readonly tagIds: readonly TagId[];
+  readonly rating?: number;
+  readonly image?: ImageAsset;
+  readonly openHours?: { readonly opensAt: string; readonly closesAt: string };
 }
 
 export interface RouteNote {
-  id: string;
-  localizations: EntityLocalizations;
+  readonly id: string;
+  readonly localizations: EntityLocalizations;
 }
 
 export interface WalkRouteSummary {

--- a/src/app/data/map.ts
+++ b/src/app/data/map.ts
@@ -30,20 +30,20 @@ export interface RouteNote {
 }
 
 export interface WalkRouteSummary {
-  id: string;
-  localizations: EntityLocalizations;
-  coverImage: ImageAsset;
-  mapImage: ImageAsset;
-  distanceMetres: number;
-  durationSeconds: number;
-  stopsCount: number;
-  difficultyId: DifficultyId;
-  rating: number;
-  saves: number;
-  lastUpdatedAt: string;
-  highlightTagIds: TagId[];
-  pointsOfInterest: WalkPointOfInterest[];
-  notes: RouteNote[];
+  readonly id: string;
+  readonly localizations: EntityLocalizations;
+  readonly coverImage: ImageAsset;
+  readonly mapImage: ImageAsset;
+  readonly distanceMetres: number;
+  readonly durationSeconds: number;
+  readonly stopsCount: number;
+  readonly difficultyId: DifficultyId;
+  readonly rating: number;
+  readonly saves: number;
+  readonly lastUpdatedAt: string;
+  readonly highlightTagIds: readonly TagId[];
+  readonly pointsOfInterest: readonly WalkPointOfInterest[];
+  readonly notes: readonly RouteNote[];
 }
 
 export const quickWalkConfig: QuickWalkConfig = {

--- a/src/app/data/offline-fixtures.ts
+++ b/src/app/data/offline-fixtures.ts
@@ -1,0 +1,63 @@
+/** @file Fixture data for offline suggestions. */
+
+import { fillLocalizations, localizeAcrossLocales } from "./fixture-localization";
+import type { OfflineSuggestion } from "./stage-four";
+
+export const offlineSuggestions: OfflineSuggestion[] = [
+  {
+    id: "reykjavik",
+    localizations: fillLocalizations(
+      localizeAcrossLocales(
+        {
+          name: "Upcoming Trip Detected",
+          description: "Add Reykjavik before your Iceland trip next week",
+        },
+        {
+          es: {
+            name: "Viaje próximo detectado",
+            description: "Añade Reikiavik antes de tu viaje a Islandia la próxima semana",
+          },
+        },
+      ),
+      "en-GB",
+      "offline-suggestion: reykjavik",
+    ),
+    ctaLocalizations: fillLocalizations(
+      localizeAcrossLocales(
+        { name: "Download Reykjavik" },
+        { es: { name: "Descargar Reikiavik" } },
+      ),
+      "en-GB",
+      "offline-suggestion-cta: reykjavik",
+    ),
+    iconToken: "{icon.object.travel}",
+    accentClass: "from-sky-500 via-indigo-500 to-purple-600",
+    iconClassName: "text-[color:var(--b3)]",
+  },
+  {
+    id: "kyoto",
+    localizations: fillLocalizations(
+      localizeAcrossLocales(
+        {
+          name: "Weekend City Break",
+          description: "Save Kyoto before your autumn temple tour",
+        },
+        {
+          ja: {
+            name: "週末シティブレイク",
+            description: "秋の寺巡りに備えて京都を保存しましょう",
+          },
+        },
+      ),
+      "en-GB",
+      "offline-suggestion: kyoto",
+    ),
+    ctaLocalizations: fillLocalizations(
+      localizeAcrossLocales({ name: "Download Kyoto" }, { ja: { name: "京都をダウンロード" } }),
+      "en-GB",
+      "offline-suggestion-cta: kyoto",
+    ),
+    iconToken: "{icon.navigation.download}",
+    accentClass: "from-amber-500 via-rose-500 to-fuchsia-600",
+  },
+];

--- a/src/app/data/registries/tags.ts
+++ b/src/app/data/registries/tags.ts
@@ -14,6 +14,8 @@ export interface TagDescriptor {
   readonly accentClass?: string;
 }
 
+export type TagId = TagDescriptor["id"];
+
 export type ResolvedTagDescriptor = TagDescriptor & { readonly localization: LocalizedStringSet };
 
 export const tagDescriptors: ReadonlyArray<TagDescriptor> = [

--- a/src/app/data/stage-four.ts
+++ b/src/app/data/stage-four.ts
@@ -115,12 +115,24 @@ export const walkCompletionMapImage = walkRouteMap1;
 
 const withBasePath = (path: string, alt: string): ImageAsset => {
   const base = import.meta.env.BASE_URL ?? "/";
+  // Ensure base ends with / before concatenation
+  const normalisedBase = base.endsWith("/") ? base : `${base}/`;
   const cleanedPath = path.replace(/^\/+/, "");
   // Collapse duplicate slashes but preserve protocol separators (://)
-  const url = `${base}${cleanedPath}`.replace(/([^:]\/)\/+/g, "$1");
+  const url = `${normalisedBase}${cleanedPath}`.replace(/([^:]\/)\/+/g, "$1");
   return { url, alt };
 };
 
+/**
+ * A suggested offline map area for the user to download.
+ *
+ * @property id - Unique identifier for the suggestion.
+ * @property localizations - Localised name and description for display.
+ * @property ctaLocalizations - Localised call-to-action button label.
+ * @property iconToken - Design token for the suggestion icon.
+ * @property accentClass - Tailwind gradient classes for the card background.
+ * @property iconClassName - Optional additional classes for icon styling.
+ */
 export interface OfflineSuggestion {
   readonly id: string;
   readonly localizations: EntityLocalizations;
@@ -130,6 +142,17 @@ export interface OfflineSuggestion {
   readonly iconClassName?: string;
 }
 
+/**
+ * A downloaded offline map area with progress and status metadata.
+ *
+ * @property id - Unique identifier for the map area.
+ * @property localizations - Localised name and description for display.
+ * @property image - Thumbnail image asset for the area.
+ * @property sizeBytes - Total download size in bytes.
+ * @property progress - Download progress as a decimal (0 to 1).
+ * @property status - Current download state: complete, updating, or downloading.
+ * @property lastUpdatedAt - ISO 8601 timestamp of last update.
+ */
 export interface OfflineMapArea {
   readonly id: string;
   readonly localizations: EntityLocalizations;
@@ -140,6 +163,16 @@ export interface OfflineMapArea {
   readonly lastUpdatedAt: string;
 }
 
+/**
+ * Configuration option for automatic offline map management.
+ *
+ * @property id - Unique identifier for the option.
+ * @property localizations - Localised name and description for display.
+ * @property iconToken - Design token for the option icon.
+ * @property iconClassName - Tailwind classes for icon styling.
+ * @property defaultEnabled - Whether the option is enabled by default.
+ * @property retentionDays - Number of days to retain maps (for auto-delete option).
+ */
 export interface AutoManagementOption {
   readonly id: string;
   readonly localizations: EntityLocalizations;

--- a/src/app/data/stage-four.ts
+++ b/src/app/data/stage-four.ts
@@ -182,64 +182,7 @@ export interface AutoManagementOption {
   readonly retentionDays?: number;
 }
 
-export const offlineSuggestions: OfflineSuggestion[] = [
-  {
-    id: "reykjavik",
-    localizations: fillLocalizations(
-      localizeAcrossLocales(
-        {
-          name: "Upcoming Trip Detected",
-          description: "Add Reykjavik before your Iceland trip next week",
-        },
-        {
-          es: {
-            name: "Viaje próximo detectado",
-            description: "Añade Reikiavik antes de tu viaje a Islandia la próxima semana",
-          },
-        },
-      ),
-      "en-GB",
-      "offline-suggestion: reykjavik",
-    ),
-    ctaLocalizations: fillLocalizations(
-      localizeAcrossLocales(
-        { name: "Download Reykjavik" },
-        { es: { name: "Descargar Reikiavik" } },
-      ),
-      "en-GB",
-      "offline-suggestion-cta: reykjavik",
-    ),
-    iconToken: "{icon.object.travel}",
-    accentClass: "from-sky-500 via-indigo-500 to-purple-600",
-    iconClassName: "text-[color:var(--b3)]",
-  },
-  {
-    id: "kyoto",
-    localizations: fillLocalizations(
-      localizeAcrossLocales(
-        {
-          name: "Weekend City Break",
-          description: "Save Kyoto before your autumn temple tour",
-        },
-        {
-          ja: {
-            name: "週末シティブレイク",
-            description: "秋の寺巡りに備えて京都を保存しましょう",
-          },
-        },
-      ),
-      "en-GB",
-      "offline-suggestion: kyoto",
-    ),
-    ctaLocalizations: fillLocalizations(
-      localizeAcrossLocales({ name: "Download Kyoto" }, { ja: { name: "京都をダウンロード" } }),
-      "en-GB",
-      "offline-suggestion-cta: kyoto",
-    ),
-    iconToken: "{icon.navigation.download}",
-    accentClass: "from-amber-500 via-rose-500 to-fuchsia-600",
-  },
-];
+export { offlineSuggestions } from "./offline-fixtures";
 
 export const offlineMapAreas: OfflineMapArea[] = [
   {

--- a/src/app/data/stage-four.ts
+++ b/src/app/data/stage-four.ts
@@ -1,7 +1,9 @@
 /** @file Data fixtures supporting Stage 4 routes (completion and safety flows). */
 
 import walkRouteMap1 from "../../assets/walks/walk-route-map-1.png";
+import type { EntityLocalizations, ImageAsset } from "../domain/entities/localization";
 import { metresFromKilometres, secondsFromMinutes } from "../units/unit-format";
+import { fillLocalizations, localizeAcrossLocales } from "./fixture-localization";
 
 export interface WalkCompletionStat {
   id: string;
@@ -49,12 +51,6 @@ export const walkCompletionSecondaryStats: WalkCompletionStat[] = [
     iconToken: "{icon.object.star}",
   },
 ];
-
-const withBasePath = (path: string): string => {
-  const base = import.meta.env.BASE_URL ?? "/";
-  const cleanedPath = path.replace(/^\/+/, "");
-  return `${base}${cleanedPath}`.replace(/\/+/g, "/");
-};
 
 export interface WalkCompletionMoment {
   id: string;
@@ -117,98 +113,191 @@ export const walkCompletionShareOptions: WalkCompletionShareOption[] = [
 
 export const walkCompletionMapImage = walkRouteMap1;
 
+const withBasePath = (path: string, alt: string): ImageAsset => {
+  const base = import.meta.env.BASE_URL ?? "/";
+  const cleanedPath = path.replace(/^\/+/, "");
+  const url = `${base}${cleanedPath}`.replace(/\/+/g, "/");
+  return { url, alt };
+};
+
 export interface OfflineSuggestion {
   id: string;
-  title: string;
-  description: string;
-  callToAction: string;
+  localizations: EntityLocalizations;
+  ctaLocalizations: EntityLocalizations;
   iconToken: string;
   accentClass: string;
   iconClassName?: string;
 }
 
+export interface OfflineMapArea {
+  id: string;
+  localizations: EntityLocalizations;
+  image: ImageAsset;
+  sizeBytes: number;
+  progress: number;
+  status: "complete" | "updating" | "downloading";
+  lastUpdatedAt: string;
+}
+
 export interface AutoManagementOption {
   id: string;
-  title: string;
-  description: string;
+  localizations: EntityLocalizations;
   iconToken: string;
   iconClassName: string;
   defaultEnabled: boolean;
+  retentionDays?: number;
 }
 
 export const offlineSuggestions: OfflineSuggestion[] = [
   {
     id: "reykjavik",
-    title: "Upcoming Trip Detected",
-    description: "Add Reykjavik before your Iceland trip next week",
-    callToAction: "Download Reykjavik",
+    localizations: fillLocalizations(
+      localizeAcrossLocales(
+        {
+          name: "Upcoming Trip Detected",
+          description: "Add Reykjavik before your Iceland trip next week",
+        },
+        {
+          es: {
+            name: "Viaje próximo detectado",
+            description: "Añade Reikiavik antes de tu viaje a Islandia la próxima semana",
+          },
+        },
+      ),
+      "en-GB",
+      "offline-suggestion: reykjavik",
+    ),
+    ctaLocalizations: fillLocalizations(
+      localizeAcrossLocales(
+        { name: "Download Reykjavik" },
+        { es: { name: "Descargar Reikiavik" } },
+      ),
+      "en-GB",
+      "offline-suggestion-cta: reykjavik",
+    ),
     iconToken: "{icon.object.travel}",
     accentClass: "from-sky-500 via-indigo-500 to-purple-600",
     iconClassName: "text-[color:var(--b3)]",
   },
+  {
+    id: "kyoto",
+    localizations: fillLocalizations(
+      localizeAcrossLocales(
+        {
+          name: "Weekend City Break",
+          description: "Save Kyoto before your autumn temple tour",
+        },
+        {
+          ja: {
+            name: "週末シティブレイク",
+            description: "秋の寺巡りに備えて京都を保存しましょう",
+          },
+        },
+      ),
+      "en-GB",
+      "offline-suggestion: kyoto",
+    ),
+    ctaLocalizations: fillLocalizations(
+      localizeAcrossLocales({ name: "Download Kyoto" }, { ja: { name: "京都をダウンロード" } }),
+      "en-GB",
+      "offline-suggestion-cta: kyoto",
+    ),
+    iconToken: "{icon.navigation.download}",
+    accentClass: "from-amber-500 via-rose-500 to-fuchsia-600",
+  },
 ];
 
-export interface OfflineDownload {
-  id: string;
-  title: string;
-  subtitle: string;
-  size: string;
-  progress: number;
-  imageUrl: string;
-  status?: "complete" | "updating" | "downloading";
-}
-
-export const offlineDownloads: OfflineDownload[] = [
+export const offlineMapAreas: OfflineMapArea[] = [
   {
     id: "nyc",
-    title: "New York, NY",
-    subtitle: "Downloaded 3 days ago",
-    size: "847 MB",
+    localizations: fillLocalizations(
+      localizeAcrossLocales(
+        { name: "New York, NY", description: "Downtown and Brooklyn offline pack" },
+        { es: { name: "Nueva York, NY", description: "Paquete offline de Downtown y Brooklyn" } },
+      ),
+      "en-GB",
+      "offline-area: nyc",
+    ),
+    image: withBasePath("images/empire.png", "Empire State Building viewed from above"),
+    sizeBytes: 847 * 1024 ** 2,
     progress: 1,
-    imageUrl: withBasePath("images/empire.png"),
     status: "complete",
+    lastUpdatedAt: "2025-11-29T15:00:00Z",
   },
   {
     id: "sf",
-    title: "San Francisco, CA",
-    subtitle: "Downloaded 1 week ago",
-    size: "623 MB",
+    localizations: fillLocalizations(
+      localizeAcrossLocales(
+        { name: "San Francisco, CA", description: "Waterfront and downtown core" },
+        { es: { name: "San Francisco, CA", description: "Embarcadero y centro de la ciudad" } },
+      ),
+      "en-GB",
+      "offline-area: sf",
+    ),
+    image: withBasePath("images/goldengate.png", "Golden Gate Bridge from an overlook"),
+    sizeBytes: 623 * 1024 ** 2,
     progress: 1,
-    imageUrl: withBasePath("images/goldengate.png"),
     status: "complete",
+    lastUpdatedAt: "2025-11-23T10:00:00Z",
   },
   {
     id: "london",
-    title: "London, UK",
-    subtitle: "Downloading • 1.2 GB",
-    size: "1.2 GB",
+    localizations: fillLocalizations(
+      localizeAcrossLocales(
+        { name: "London, UK", description: "Central London with Thames overlays" },
+        { es: { name: "Londres, Reino Unido", description: "Centro de Londres y el Támesis" } },
+      ),
+      "en-GB",
+      "offline-area: london",
+    ),
+    image: withBasePath("images/londoneye.png", "London skyline with the London Eye"),
+    sizeBytes: Math.round(1.2 * 1024 ** 3),
     progress: 0.65,
-    imageUrl: withBasePath("images/londoneye.png"),
     status: "downloading",
+    lastUpdatedAt: "2025-12-04T08:30:00Z",
   },
 ];
 
 export const autoManagementOptions: AutoManagementOption[] = [
   {
     id: "auto-delete",
-    title: "Auto-delete old maps",
-    description: "Remove maps older than 30 days automatically",
+    localizations: fillLocalizations(
+      localizeAcrossLocales({
+        name: "Auto-delete old maps",
+        description: "Remove maps after a retention window",
+      }),
+      "en-GB",
+      "offline-auto: auto-delete",
+    ),
     iconToken: "{icon.offline.delete}",
     iconClassName: "text-amber-400",
     defaultEnabled: true,
+    retentionDays: 30,
   },
   {
     id: "wifi-only",
-    title: "Wi-Fi-only downloads",
-    description: "Only download maps when connected to Wi-Fi",
+    localizations: fillLocalizations(
+      localizeAcrossLocales({
+        name: "Wi-Fi-only downloads",
+        description: "Download maps only on trusted networks",
+      }),
+      "en-GB",
+      "offline-auto: wifi-only",
+    ),
     iconToken: "{icon.offline.connectivity}",
     iconClassName: "text-accent",
     defaultEnabled: true,
   },
   {
     id: "auto-update",
-    title: "Auto-update maps",
-    description: "Automatically update maps when new versions are available",
+    localizations: fillLocalizations(
+      localizeAcrossLocales({
+        name: "Auto-update maps",
+        description: "Keep offline areas fresh in the background",
+      }),
+      "en-GB",
+      "offline-auto: auto-update",
+    ),
     iconToken: "{icon.offline.sync}",
     iconClassName: "text-purple-400",
     defaultEnabled: false,

--- a/src/app/data/stage-four.ts
+++ b/src/app/data/stage-four.ts
@@ -141,12 +141,12 @@ export interface OfflineMapArea {
 }
 
 export interface AutoManagementOption {
-  id: string;
-  localizations: EntityLocalizations;
-  iconToken: string;
-  iconClassName: string;
-  defaultEnabled: boolean;
-  retentionDays?: number;
+  readonly id: string;
+  readonly localizations: EntityLocalizations;
+  readonly iconToken: string;
+  readonly iconClassName: string;
+  readonly defaultEnabled: boolean;
+  readonly retentionDays?: number;
 }
 
 export const offlineSuggestions: OfflineSuggestion[] = [

--- a/src/app/data/stage-four.ts
+++ b/src/app/data/stage-four.ts
@@ -116,27 +116,28 @@ export const walkCompletionMapImage = walkRouteMap1;
 const withBasePath = (path: string, alt: string): ImageAsset => {
   const base = import.meta.env.BASE_URL ?? "/";
   const cleanedPath = path.replace(/^\/+/, "");
-  const url = `${base}${cleanedPath}`.replace(/\/+/g, "/");
+  // Collapse duplicate slashes but preserve protocol separators (://)
+  const url = `${base}${cleanedPath}`.replace(/([^:]\/)\/+/g, "$1");
   return { url, alt };
 };
 
 export interface OfflineSuggestion {
-  id: string;
-  localizations: EntityLocalizations;
-  ctaLocalizations: EntityLocalizations;
-  iconToken: string;
-  accentClass: string;
-  iconClassName?: string;
+  readonly id: string;
+  readonly localizations: EntityLocalizations;
+  readonly ctaLocalizations: EntityLocalizations;
+  readonly iconToken: string;
+  readonly accentClass: string;
+  readonly iconClassName?: string;
 }
 
 export interface OfflineMapArea {
-  id: string;
-  localizations: EntityLocalizations;
-  image: ImageAsset;
-  sizeBytes: number;
-  progress: number;
-  status: "complete" | "updating" | "downloading";
-  lastUpdatedAt: string;
+  readonly id: string;
+  readonly localizations: EntityLocalizations;
+  readonly image: ImageAsset;
+  readonly sizeBytes: number;
+  readonly progress: number;
+  readonly status: "complete" | "updating" | "downloading";
+  readonly lastUpdatedAt: string;
 }
 
 export interface AutoManagementOption {

--- a/src/app/features/map/itinerary/components/itinerary-map-header.tsx
+++ b/src/app/features/map/itinerary/components/itinerary-map-header.tsx
@@ -1,6 +1,7 @@
 /** @file Top header bar for the itinerary map view with stats and navigation. */
 
 import type { JSX } from "react";
+import { useTranslation } from "react-i18next";
 
 import { Icon } from "../../../../components/icon";
 import { MapRouteStat } from "../../../../components/map/map-route-stat";
@@ -22,12 +23,16 @@ export function ItineraryMapHeader({
   labels,
   onBack,
 }: ItineraryMapHeaderProps): JSX.Element {
+  const { t } = useTranslation();
+  const backLabel = t("action-back", { defaultValue: "Back" });
+  const locateLabel = t("action-locate", { defaultValue: "Locate" });
+
   return (
     <div className="flex items-center justify-between">
       <button
         type="button"
         className="circle-action-button--ghost"
-        aria-label="Back"
+        aria-label={backLabel}
         onClick={onBack}
       >
         <Icon token="{icon.navigation.back}" aria-hidden className="h-5 w-5" />
@@ -39,7 +44,13 @@ export function ItineraryMapHeader({
           <MapRouteStat label={labels.stops} value={`${stops.value} ${stops.unitLabel}`} />
         </div>
       </div>
-      <button type="button" className="circle-action-button--ghost" aria-label="Locate">
+      {/* Locate button disabled until geolocation callback is wired */}
+      <button
+        type="button"
+        className="circle-action-button--ghost"
+        aria-label={locateLabel}
+        disabled
+      >
         <Icon token="{icon.object.locationArrow}" aria-hidden className="h-5 w-5" />
       </button>
     </div>

--- a/src/app/features/map/itinerary/components/itinerary-map-header.tsx
+++ b/src/app/features/map/itinerary/components/itinerary-map-header.tsx
@@ -1,0 +1,60 @@
+/** @file Top header bar for the itinerary map view with stats and navigation. */
+
+import type { JSX } from "react";
+
+import { Icon } from "../../../../components/icon";
+import type { LocalisedUnitValue } from "../../../../units/unit-format";
+import type { ItineraryLabels } from "../hooks/use-itinerary-data";
+
+type MapRouteStatProps = {
+  readonly label: string;
+  readonly value: string | number;
+};
+
+function MapRouteStat({ label, value }: MapRouteStatProps): JSX.Element {
+  return (
+    <span className="map-route__stat">
+      <p className="map-route__stat-value">{value}</p>
+      {label}
+    </span>
+  );
+}
+
+export type ItineraryMapHeaderProps = {
+  readonly distance: LocalisedUnitValue;
+  readonly duration: LocalisedUnitValue;
+  readonly stops: LocalisedUnitValue;
+  readonly labels: ItineraryLabels;
+  readonly onBack: () => void;
+};
+
+export function ItineraryMapHeader({
+  distance,
+  duration,
+  stops,
+  labels,
+  onBack,
+}: ItineraryMapHeaderProps): JSX.Element {
+  return (
+    <div className="flex items-center justify-between">
+      <button
+        type="button"
+        className="circle-action-button--ghost"
+        aria-label="Back"
+        onClick={onBack}
+      >
+        <Icon token="{icon.navigation.back}" aria-hidden className="h-5 w-5" />
+      </button>
+      <div className="map-route__meta">
+        <div className="flex items-center gap-4">
+          <MapRouteStat label={labels.distance} value={`${distance.value} ${distance.unitLabel}`} />
+          <MapRouteStat label={labels.duration} value={`${duration.value} ${duration.unitLabel}`} />
+          <MapRouteStat label={labels.stops} value={`${stops.value} ${stops.unitLabel}`} />
+        </div>
+      </div>
+      <button type="button" className="circle-action-button--ghost" aria-label="Locate">
+        <Icon token="{icon.object.locationArrow}" aria-hidden className="h-5 w-5" />
+      </button>
+    </div>
+  );
+}

--- a/src/app/features/map/itinerary/components/itinerary-map-header.tsx
+++ b/src/app/features/map/itinerary/components/itinerary-map-header.tsx
@@ -3,22 +3,9 @@
 import type { JSX } from "react";
 
 import { Icon } from "../../../../components/icon";
+import { MapRouteStat } from "../../../../components/map/map-route-stat";
 import type { LocalisedUnitValue } from "../../../../units/unit-format";
 import type { ItineraryLabels } from "../hooks/use-itinerary-data";
-
-type MapRouteStatProps = {
-  readonly label: string;
-  readonly value: string | number;
-};
-
-function MapRouteStat({ label, value }: MapRouteStatProps): JSX.Element {
-  return (
-    <span className="map-route__stat">
-      <p className="map-route__stat-value">{value}</p>
-      {label}
-    </span>
-  );
-}
 
 export type ItineraryMapHeaderProps = {
   readonly distance: LocalisedUnitValue;

--- a/src/app/features/map/itinerary/components/notes-overlay-panel.tsx
+++ b/src/app/features/map/itinerary/components/notes-overlay-panel.tsx
@@ -1,0 +1,27 @@
+/** @file Overlay panel displaying route notes. */
+
+import type { JSX } from "react";
+
+import type { RouteNote } from "../../../../data/map";
+import { pickLocalization } from "../../../../domain/entities/localization";
+
+export type NotesOverlayPanelProps = {
+  readonly notes: readonly RouteNote[];
+  readonly language: string;
+};
+
+export function NotesOverlayPanel({ notes, language }: NotesOverlayPanelProps): JSX.Element {
+  return (
+    <div className="pointer-events-none px-6 pb-6">
+      <div className="map-panel map-panel--scroll map-panel__notes">
+        <p className="text-base font-semibold text-base-content">Route notes</p>
+        <ul className="mt-3 route-note-list" aria-label="Route notes">
+          {notes.map((note) => {
+            const noteCopy = pickLocalization(note.localizations, language);
+            return <li key={note.id}>{noteCopy.name}</li>;
+          })}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/app/features/map/itinerary/components/route-action-buttons.tsx
+++ b/src/app/features/map/itinerary/components/route-action-buttons.tsx
@@ -1,0 +1,61 @@
+/** @file Favourite toggle and share dialog for a route. */
+
+import * as Dialog from "@radix-ui/react-dialog";
+import { type JSX, useState } from "react";
+
+import { Icon } from "../../../../components/icon";
+
+export type RouteActionButtonsProps = {
+  readonly routeId: string;
+};
+
+export function RouteActionButtons({ routeId }: RouteActionButtonsProps): JSX.Element {
+  const [isFavourite, setIsFavourite] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
+
+  return (
+    <div className="flex justify-end gap-3">
+      <button
+        type="button"
+        className={`flex h-10 w-10 items-center justify-center rounded-full border border-base-300/60 transition ${
+          isFavourite ? "bg-accent text-base-900" : "bg-base-200/70 text-base-content"
+        }`}
+        aria-label={isFavourite ? "Remove saved itinerary" : "Save this itinerary"}
+        aria-pressed={isFavourite}
+        onClick={() => setIsFavourite((prev) => !prev)}
+      >
+        <Icon token={isFavourite ? "{icon.action.like}" : "{icon.action.unlike}"} aria-hidden />
+      </button>
+      <Dialog.Root open={shareOpen} onOpenChange={setShareOpen}>
+        <Dialog.Trigger asChild>
+          <button type="button" className="route-share__trigger">
+            <Icon token="{icon.action.share}" aria-hidden />
+            Share
+          </button>
+        </Dialog.Trigger>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 bg-black/60" />
+          <Dialog.Content className="dialog-surface">
+            <Dialog.Title className="text-lg font-semibold text-base-content">
+              Share this walk
+            </Dialog.Title>
+            <Dialog.Description className="text-sm text-base-content/70">
+              Copy the preview link or send it to friends once real sharing is wired up.
+            </Dialog.Description>
+            <div className="route-share__preview">https://wildside.app/routes/{routeId}</div>
+            <div className="flex justify-end gap-2">
+              <Dialog.Close asChild>
+                <button type="button" className="btn btn-ghost btn-sm">
+                  Close
+                </button>
+              </Dialog.Close>
+              <button type="button" className="btn btn-accent btn-sm" disabled>
+                Coming soon
+              </button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </div>
+  );
+}

--- a/src/app/features/map/itinerary/components/route-action-buttons.tsx
+++ b/src/app/features/map/itinerary/components/route-action-buttons.tsx
@@ -31,9 +31,8 @@ export function RouteActionButtons({ routeId }: RouteActionButtonsProps): JSX.El
   return (
     <div className="flex justify-end gap-3">
       <Button
-        className={`flex h-10 w-10 items-center justify-center rounded-full border border-base-300/60 transition ${
-          isFavourite ? "bg-accent text-base-900" : "bg-base-200/70 text-base-content"
-        }`}
+        variant="circle"
+        active={isFavourite}
         aria-label={isFavourite ? removeSavedLabel : saveLabel}
         aria-pressed={isFavourite}
         onClick={() => setIsFavourite((prev) => !prev)}

--- a/src/app/features/map/itinerary/components/route-action-buttons.tsx
+++ b/src/app/features/map/itinerary/components/route-action-buttons.tsx
@@ -2,7 +2,9 @@
 
 import * as Dialog from "@radix-ui/react-dialog";
 import { type JSX, useState } from "react";
+import { useTranslation } from "react-i18next";
 
+import { Button } from "../../../../components/button";
 import { Icon } from "../../../../components/icon";
 
 export type RouteActionButtonsProps = {
@@ -10,48 +12,60 @@ export type RouteActionButtonsProps = {
 };
 
 export function RouteActionButtons({ routeId }: RouteActionButtonsProps): JSX.Element {
+  const { t } = useTranslation();
   const [isFavourite, setIsFavourite] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
 
+  const removeSavedLabel = t("route-action-remove-saved", {
+    defaultValue: "Remove saved itinerary",
+  });
+  const saveLabel = t("route-action-save", { defaultValue: "Save this itinerary" });
+  const shareLabel = t("route-action-share", { defaultValue: "Share" });
+  const shareDialogTitle = t("route-share-dialog-title", { defaultValue: "Share this walk" });
+  const shareDialogDescription = t("route-share-dialog-description", {
+    defaultValue: "Copy the preview link or send it to friends once real sharing is wired up.",
+  });
+  const closeLabel = t("action-close", { defaultValue: "Close" });
+  const comingSoonLabel = t("route-action-coming-soon", { defaultValue: "Coming soon" });
+
   return (
     <div className="flex justify-end gap-3">
-      <button
-        type="button"
+      <Button
         className={`flex h-10 w-10 items-center justify-center rounded-full border border-base-300/60 transition ${
           isFavourite ? "bg-accent text-base-900" : "bg-base-200/70 text-base-content"
         }`}
-        aria-label={isFavourite ? "Remove saved itinerary" : "Save this itinerary"}
+        aria-label={isFavourite ? removeSavedLabel : saveLabel}
         aria-pressed={isFavourite}
         onClick={() => setIsFavourite((prev) => !prev)}
       >
         <Icon token={isFavourite ? "{icon.action.like}" : "{icon.action.unlike}"} aria-hidden />
-      </button>
+      </Button>
       <Dialog.Root open={shareOpen} onOpenChange={setShareOpen}>
         <Dialog.Trigger asChild>
-          <button type="button" className="route-share__trigger">
+          <Button className="route-share__trigger">
             <Icon token="{icon.action.share}" aria-hidden />
-            Share
-          </button>
+            {shareLabel}
+          </Button>
         </Dialog.Trigger>
         <Dialog.Portal>
           <Dialog.Overlay className="fixed inset-0 bg-black/60" />
           <Dialog.Content className="dialog-surface">
             <Dialog.Title className="text-lg font-semibold text-base-content">
-              Share this walk
+              {shareDialogTitle}
             </Dialog.Title>
             <Dialog.Description className="text-sm text-base-content/70">
-              Copy the preview link or send it to friends once real sharing is wired up.
+              {shareDialogDescription}
             </Dialog.Description>
             <div className="route-share__preview">https://wildside.app/routes/{routeId}</div>
             <div className="flex justify-end gap-2">
               <Dialog.Close asChild>
-                <button type="button" className="btn btn-ghost btn-sm">
-                  Close
-                </button>
+                <Button variant="ghost" size="sm">
+                  {closeLabel}
+                </Button>
               </Dialog.Close>
-              <button type="button" className="btn btn-accent btn-sm" disabled>
-                Coming soon
-              </button>
+              <Button variant="accent" size="sm" disabled>
+                {comingSoonLabel}
+              </Button>
             </div>
           </Dialog.Content>
         </Dialog.Portal>

--- a/src/app/features/map/itinerary/components/route-action-buttons.tsx
+++ b/src/app/features/map/itinerary/components/route-action-buttons.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 
 import { Button } from "../../../../components/button";
 import { Icon } from "../../../../components/icon";
+import { getRouteShareUrl } from "../../../../config/route-urls";
 
 export type RouteActionButtonsProps = {
   readonly routeId: string;
@@ -55,7 +56,7 @@ export function RouteActionButtons({ routeId }: RouteActionButtonsProps): JSX.El
             <Dialog.Description className="text-sm text-base-content/70">
               {shareDialogDescription}
             </Dialog.Description>
-            <div className="route-share__preview">https://wildside.app/routes/{routeId}</div>
+            <div className="route-share__preview">{getRouteShareUrl(routeId)}</div>
             <div className="flex justify-end gap-2">
               <Dialog.Close asChild>
                 <Button variant="ghost" size="sm">

--- a/src/app/features/map/itinerary/components/route-summary-section.tsx
+++ b/src/app/features/map/itinerary/components/route-summary-section.tsx
@@ -1,0 +1,39 @@
+/** @file Route summary with title, description, and highlight tags. */
+
+import type { JSX } from "react";
+
+import type { TagId } from "../../../../data/registries/tags";
+import { getTagDescriptor } from "../../../../data/registries/tags";
+
+export type RouteSummarySectionProps = {
+  readonly routeName: string;
+  readonly routeDescription: string | undefined;
+  readonly highlightTagIds: readonly TagId[];
+  readonly language: string;
+};
+
+export function RouteSummarySection({
+  routeName,
+  routeDescription,
+  highlightTagIds,
+  language,
+}: RouteSummarySectionProps): JSX.Element {
+  return (
+    <div className="map-route__summary">
+      <p className="text-sm font-medium text-base-content/60">Suggested route</p>
+      <h1 className="mt-1 text-2xl font-semibold text-base-content">{routeName}</h1>
+      <p className="mt-3 text-sm text-base-content/70">{routeDescription}</p>
+      <div className="mt-4 flex flex-wrap gap-2">
+        {highlightTagIds.map((tagId) => {
+          const tag = getTagDescriptor(tagId, language);
+          const label = tag?.localization.name ?? tagId;
+          return (
+            <span key={tagId} className="route-highlight">
+              {label}
+            </span>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/features/map/itinerary/components/route-summary-section.tsx
+++ b/src/app/features/map/itinerary/components/route-summary-section.tsx
@@ -1,6 +1,7 @@
 /** @file Route summary with title, description, and highlight tags. */
 
 import type { JSX } from "react";
+import { useTranslation } from "react-i18next";
 
 import type { TagId } from "../../../../data/registries/tags";
 import { getTagDescriptor } from "../../../../data/registries/tags";
@@ -18,9 +19,14 @@ export function RouteSummarySection({
   highlightTagIds,
   language,
 }: RouteSummarySectionProps): JSX.Element {
+  const { t } = useTranslation();
+  const suggestedRouteCaption = t("route-summary-suggested-caption", {
+    defaultValue: "Suggested route",
+  });
+
   return (
     <div className="map-route__summary">
-      <p className="text-sm font-medium text-base-content/60">Suggested route</p>
+      <p className="text-sm font-medium text-base-content/60">{suggestedRouteCaption}</p>
       <h1 className="mt-1 text-2xl font-semibold text-base-content">{routeName}</h1>
       <p className="mt-3 text-sm text-base-content/70">{routeDescription}</p>
       <div className="mt-4 flex flex-wrap gap-2">

--- a/src/app/features/map/itinerary/components/route-summary-section.tsx
+++ b/src/app/features/map/itinerary/components/route-summary-section.tsx
@@ -1,6 +1,6 @@
 /** @file Route summary with title, description, and highlight tags. */
 
-import type { JSX } from "react";
+import { type JSX, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { TagId } from "../../../../data/registries/tags";
@@ -24,6 +24,15 @@ export function RouteSummarySection({
     defaultValue: "Suggested route",
   });
 
+  const tagLabels = useMemo(
+    () =>
+      highlightTagIds.map((tagId) => {
+        const tag = getTagDescriptor(tagId, language);
+        return { tagId, label: tag?.localization.name ?? tagId };
+      }),
+    [highlightTagIds, language],
+  );
+
   return (
     <div className="map-route__summary">
       <p className="text-sm font-medium text-base-content/60">{suggestedRouteCaption}</p>
@@ -32,15 +41,11 @@ export function RouteSummarySection({
         <p className="mt-3 text-sm text-base-content/70">{routeDescription}</p>
       ) : null}
       <div className="mt-4 flex flex-wrap gap-2">
-        {highlightTagIds.map((tagId) => {
-          const tag = getTagDescriptor(tagId, language);
-          const label = tag?.localization.name ?? tagId;
-          return (
-            <span key={tagId} className="route-highlight">
-              {label}
-            </span>
-          );
-        })}
+        {tagLabels.map(({ tagId, label }) => (
+          <span key={tagId} className="route-highlight">
+            {label}
+          </span>
+        ))}
       </div>
     </div>
   );

--- a/src/app/features/map/itinerary/components/route-summary-section.tsx
+++ b/src/app/features/map/itinerary/components/route-summary-section.tsx
@@ -28,7 +28,9 @@ export function RouteSummarySection({
     <div className="map-route__summary">
       <p className="text-sm font-medium text-base-content/60">{suggestedRouteCaption}</p>
       <h1 className="mt-1 text-2xl font-semibold text-base-content">{routeName}</h1>
-      <p className="mt-3 text-sm text-base-content/70">{routeDescription}</p>
+      {routeDescription ? (
+        <p className="mt-3 text-sm text-base-content/70">{routeDescription}</p>
+      ) : null}
       <div className="mt-4 flex flex-wrap gap-2">
         {highlightTagIds.map((tagId) => {
           const tag = getTagDescriptor(tagId, language);

--- a/src/app/features/map/itinerary/components/stops-overlay-panel.tsx
+++ b/src/app/features/map/itinerary/components/stops-overlay-panel.tsx
@@ -1,8 +1,9 @@
 /** @file Overlay panel displaying stops along a route. */
 
 import type { JSX } from "react";
+import { useTranslation } from "react-i18next";
 
-import { STICKY_HANDLE_CLASS } from "../../../../components/map/map-panel-constants";
+import { DRAGGABLE_HANDLE_CLASS } from "../../../../components/map/map-panel-constants";
 import { PointOfInterestList } from "../../../../components/point-of-interest-list";
 import type { WalkPointOfInterest } from "../../../../data/map";
 
@@ -12,6 +13,9 @@ export type StopsOverlayPanelProps = {
 };
 
 export function StopsOverlayPanel({ points, onDismiss }: StopsOverlayPanelProps): JSX.Element {
+  const { t } = useTranslation();
+  const dismissLabel = t("action-dismiss-panel", { defaultValue: "Dismiss panel" });
+
   return (
     <div className="pointer-events-none px-6 pb-6">
       {/* Limit overlay to 60% viewport height to preserve map visibility */}
@@ -19,8 +23,8 @@ export function StopsOverlayPanel({ points, onDismiss }: StopsOverlayPanelProps)
         <div className="map-panel__handle bg-transparent">
           <button
             type="button"
-            className={STICKY_HANDLE_CLASS}
-            aria-label="Dismiss panel"
+            className={DRAGGABLE_HANDLE_CLASS}
+            aria-label={dismissLabel}
             onClick={onDismiss}
           />
         </div>

--- a/src/app/features/map/itinerary/components/stops-overlay-panel.tsx
+++ b/src/app/features/map/itinerary/components/stops-overlay-panel.tsx
@@ -8,7 +8,7 @@ import { PointOfInterestList } from "../../../../components/point-of-interest-li
 import type { WalkPointOfInterest } from "../../../../data/map";
 
 export type StopsOverlayPanelProps = {
-  readonly points: WalkPointOfInterest[];
+  readonly points: readonly WalkPointOfInterest[];
   readonly onDismiss: () => void;
 };
 

--- a/src/app/features/map/itinerary/components/stops-overlay-panel.tsx
+++ b/src/app/features/map/itinerary/components/stops-overlay-panel.tsx
@@ -1,0 +1,35 @@
+/** @file Overlay panel displaying stops along a route. */
+
+import type { JSX } from "react";
+
+import { PointOfInterestList } from "../../../../components/point-of-interest-list";
+import type { WalkPointOfInterest } from "../../../../data/map";
+
+const stickyHandleClass = "mx-auto block h-2 w-12 rounded-full bg-base-300/70";
+
+export type StopsOverlayPanelProps = {
+  readonly points: WalkPointOfInterest[];
+  readonly onDismiss: () => void;
+};
+
+export function StopsOverlayPanel({ points, onDismiss }: StopsOverlayPanelProps): JSX.Element {
+  return (
+    <div className="pointer-events-none px-6 pb-6">
+      <div className="map-panel map-panel--stacked max-h-[60vh]">
+        <div className="map-panel__handle bg-transparent">
+          <button
+            type="button"
+            className={stickyHandleClass}
+            aria-label="Dismiss panel"
+            onClick={onDismiss}
+          />
+        </div>
+        <div className="map-panel__body">
+          <PointOfInterestList points={points} />
+        </div>
+        <div className="map-overlay__fade map-overlay__fade--top" aria-hidden="true" />
+        <div className="map-overlay__fade map-overlay__fade--bottom" aria-hidden="true" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/features/map/itinerary/components/stops-overlay-panel.tsx
+++ b/src/app/features/map/itinerary/components/stops-overlay-panel.tsx
@@ -2,10 +2,9 @@
 
 import type { JSX } from "react";
 
+import { STICKY_HANDLE_CLASS } from "../../../../components/map/map-panel-constants";
 import { PointOfInterestList } from "../../../../components/point-of-interest-list";
 import type { WalkPointOfInterest } from "../../../../data/map";
-
-const stickyHandleClass = "mx-auto block h-2 w-12 rounded-full bg-base-300/70";
 
 export type StopsOverlayPanelProps = {
   readonly points: WalkPointOfInterest[];
@@ -15,11 +14,12 @@ export type StopsOverlayPanelProps = {
 export function StopsOverlayPanel({ points, onDismiss }: StopsOverlayPanelProps): JSX.Element {
   return (
     <div className="pointer-events-none px-6 pb-6">
+      {/* Limit overlay to 60% viewport height to preserve map visibility */}
       <div className="map-panel map-panel--stacked max-h-[60vh]">
         <div className="map-panel__handle bg-transparent">
           <button
             type="button"
-            className={stickyHandleClass}
+            className={STICKY_HANDLE_CLASS}
             aria-label="Dismiss panel"
             onClick={onDismiss}
           />

--- a/src/app/features/map/itinerary/hooks/use-itinerary-data.ts
+++ b/src/app/features/map/itinerary/hooks/use-itinerary-data.ts
@@ -62,13 +62,14 @@ export const useItineraryData = (route: WalkRouteSummary): ItineraryData => {
     [route.localizations, i18n.language],
   );
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: i18n.language forces re-computation when language changes
   const labels = useMemo<ItineraryLabels>(
     () => ({
       distance: t("map-itinerary-distance-label", { defaultValue: "Distance" }),
       duration: t("map-itinerary-duration-label", { defaultValue: "Walking" }),
       stops: t("map-itinerary-stops-label", { defaultValue: "Stops" }),
     }),
-    [t],
+    [t, i18n.language],
   );
 
   return useMemo(

--- a/src/app/features/map/itinerary/hooks/use-itinerary-data.ts
+++ b/src/app/features/map/itinerary/hooks/use-itinerary-data.ts
@@ -32,30 +32,54 @@ export const useItineraryData = (route: WalkRouteSummary): ItineraryData => {
     [i18n.language, t, unitSystem],
   );
 
-  const distance = formatDistance(route.distanceMetres, unitOptions);
-  const duration = formatDuration(route.durationSeconds, {
-    ...unitOptions,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  });
-  const stops = formatStops(route.stopsCount, {
-    ...unitOptions,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  });
-  const routeCopy = pickLocalization(route.localizations, i18n.language);
-  const labels: ItineraryLabels = {
-    distance: t("map-itinerary-distance-label", { defaultValue: "Distance" }),
-    duration: t("map-itinerary-duration-label", { defaultValue: "Walking" }),
-    stops: t("map-itinerary-stops-label", { defaultValue: "Stops" }),
-  };
+  const distance = useMemo(
+    () => formatDistance(route.distanceMetres, unitOptions),
+    [route.distanceMetres, unitOptions],
+  );
 
-  return {
-    language: i18n.language,
-    routeCopy,
-    distance,
-    duration,
-    stops,
-    labels,
-  };
+  const duration = useMemo(
+    () =>
+      formatDuration(route.durationSeconds, {
+        ...unitOptions,
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+      }),
+    [route.durationSeconds, unitOptions],
+  );
+
+  const stops = useMemo(
+    () =>
+      formatStops(route.stopsCount, {
+        ...unitOptions,
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+      }),
+    [route.stopsCount, unitOptions],
+  );
+
+  const routeCopy = useMemo(
+    () => pickLocalization(route.localizations, i18n.language),
+    [route.localizations, i18n.language],
+  );
+
+  const labels = useMemo<ItineraryLabels>(
+    () => ({
+      distance: t("map-itinerary-distance-label", { defaultValue: "Distance" }),
+      duration: t("map-itinerary-duration-label", { defaultValue: "Walking" }),
+      stops: t("map-itinerary-stops-label", { defaultValue: "Stops" }),
+    }),
+    [t],
+  );
+
+  return useMemo(
+    () => ({
+      language: i18n.language,
+      routeCopy,
+      distance,
+      duration,
+      stops,
+      labels,
+    }),
+    [i18n.language, routeCopy, distance, duration, stops, labels],
+  );
 };

--- a/src/app/features/map/itinerary/hooks/use-itinerary-data.ts
+++ b/src/app/features/map/itinerary/hooks/use-itinerary-data.ts
@@ -1,0 +1,61 @@
+/** @file Hook to prepare formatted and localised data for an itinerary route. */
+
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { WalkRouteSummary } from "../../../../data/map";
+import { pickLocalization } from "../../../../domain/entities/localization";
+import { formatDistance, formatDuration, formatStops } from "../../../../units/unit-format";
+import { useUnitPreferences } from "../../../../units/unit-preferences-provider";
+
+export type ItineraryLabels = {
+  readonly distance: string;
+  readonly duration: string;
+  readonly stops: string;
+};
+
+export type ItineraryData = {
+  readonly language: string;
+  readonly routeCopy: ReturnType<typeof pickLocalization>;
+  readonly distance: ReturnType<typeof formatDistance>;
+  readonly duration: ReturnType<typeof formatDuration>;
+  readonly stops: ReturnType<typeof formatStops>;
+  readonly labels: ItineraryLabels;
+};
+
+export const useItineraryData = (route: WalkRouteSummary): ItineraryData => {
+  const { t, i18n } = useTranslation();
+  const { unitSystem } = useUnitPreferences();
+
+  const unitOptions = useMemo(
+    () => ({ t, locale: i18n.language, unitSystem }),
+    [i18n.language, t, unitSystem],
+  );
+
+  const distance = formatDistance(route.distanceMetres, unitOptions);
+  const duration = formatDuration(route.durationSeconds, {
+    ...unitOptions,
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  });
+  const stops = formatStops(route.stopsCount, {
+    ...unitOptions,
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  });
+  const routeCopy = pickLocalization(route.localizations, i18n.language);
+  const labels: ItineraryLabels = {
+    distance: t("map-itinerary-distance-label", { defaultValue: "Distance" }),
+    duration: t("map-itinerary-duration-label", { defaultValue: "Walking" }),
+    stops: t("map-itinerary-stops-label", { defaultValue: "Stops" }),
+  };
+
+  return {
+    language: i18n.language,
+    routeCopy,
+    distance,
+    duration,
+    stops,
+    labels,
+  };
+};

--- a/src/app/features/map/itinerary/itinerary-screen.tsx
+++ b/src/app/features/map/itinerary/itinerary-screen.tsx
@@ -13,6 +13,8 @@ import { MapViewport } from "../../../components/map-viewport";
 import { PointOfInterestList } from "../../../components/point-of-interest-list";
 import { WildsideMap } from "../../../components/wildside-map";
 import { waterfrontDiscoveryRoute } from "../../../data/map";
+import { getTagDescriptor } from "../../../data/registries/tags";
+import { pickLocalization } from "../../../domain/entities/localization";
 import { MobileShell } from "../../../layout/mobile-shell";
 import { formatDistance, formatDuration, formatStops } from "../../../units/unit-format";
 import { useUnitPreferences } from "../../../units/unit-preferences-provider";
@@ -62,6 +64,7 @@ export function ItineraryScreen(): JSX.Element {
     minimumFractionDigits: 0,
     maximumFractionDigits: 0,
   });
+  const routeCopy = pickLocalization(waterfrontDiscoveryRoute.localizations, i18n.language);
   const distanceLabel = t("map-itinerary-distance-label", { defaultValue: "Distance" });
   const durationLabel = t("map-itinerary-duration-label", { defaultValue: "Walking" });
   const stopsLabel = t("map-itinerary-stops-label", { defaultValue: "Stops" });
@@ -118,17 +121,19 @@ export function ItineraryScreen(): JSX.Element {
                     <div className="map-route__summary">
                       <p className="text-sm font-medium text-base-content/60">Suggested route</p>
                       <h1 className="mt-1 text-2xl font-semibold text-base-content">
-                        {waterfrontDiscoveryRoute.title}
+                        {routeCopy.name}
                       </h1>
-                      <p className="mt-3 text-sm text-base-content/70">
-                        {waterfrontDiscoveryRoute.description}
-                      </p>
+                      <p className="mt-3 text-sm text-base-content/70">{routeCopy.description}</p>
                       <div className="mt-4 flex flex-wrap gap-2">
-                        {waterfrontDiscoveryRoute.highlights.map((highlight) => (
-                          <span key={highlight} className="route-highlight">
-                            {highlight}
-                          </span>
-                        ))}
+                        {waterfrontDiscoveryRoute.highlightTagIds.map((tagId) => {
+                          const tag = getTagDescriptor(tagId, i18n.language);
+                          const label = tag?.localization.name ?? tagId;
+                          return (
+                            <span key={tagId} className="route-highlight">
+                              {label}
+                            </span>
+                          );
+                        })}
                       </div>
                     </div>
 
@@ -213,9 +218,10 @@ export function ItineraryScreen(): JSX.Element {
                 <div className="map-panel map-panel--scroll map-panel__notes">
                   <p className="text-base font-semibold text-base-content">Route notes</p>
                   <ul className="mt-3 route-note-list" aria-label="Route notes">
-                    {waterfrontDiscoveryRoute.notes.map((note) => (
-                      <li key={note}>{note}</li>
-                    ))}
+                    {waterfrontDiscoveryRoute.notes.map((note) => {
+                      const noteCopy = pickLocalization(note.localizations, i18n.language);
+                      return <li key={note.id}>{noteCopy.name}</li>;
+                    })}
                   </ul>
                 </div>
               </div>

--- a/src/app/features/map/itinerary/itinerary-screen.tsx
+++ b/src/app/features/map/itinerary/itinerary-screen.tsx
@@ -3,7 +3,7 @@
 import type { TabsContentProps } from "@radix-ui/react-tabs";
 import * as Tabs from "@radix-ui/react-tabs";
 import { useNavigate } from "@tanstack/react-router";
-import { type JSX, useState } from "react";
+import { type JSX, useCallback, useState } from "react";
 
 import { MapBottomNavigation } from "../../../components/map-bottom-navigation";
 import { MapViewport } from "../../../components/map-viewport";
@@ -33,8 +33,8 @@ export function ItineraryScreen(): JSX.Element {
   const { language, routeCopy, distance, duration, stops, labels } =
     useItineraryData(waterfrontDiscoveryRoute);
 
-  const handleBack = () => navigate({ to: "/map/quick" });
-  const handleDismissStops = () => setActiveTab("map");
+  const handleBack = useCallback(() => navigate({ to: "/map/quick" }), [navigate]);
+  const handleDismissStops = useCallback(() => setActiveTab("map"), []);
 
   return (
     <MobileShell tone="dark">

--- a/src/app/features/map/itinerary/itinerary-screen.tsx
+++ b/src/app/features/map/itinerary/itinerary-screen.tsx
@@ -1,28 +1,24 @@
 /** @file Map itinerary route with MapLibre canvas, tabs, and POI details. */
 
-import * as Dialog from "@radix-ui/react-dialog";
 import type { TabsContentProps } from "@radix-ui/react-tabs";
 import * as Tabs from "@radix-ui/react-tabs";
 import { useNavigate } from "@tanstack/react-router";
-import { type JSX, useMemo, useState } from "react";
-import { useTranslation } from "react-i18next";
+import { type JSX, useState } from "react";
 
-import { Icon } from "../../../components/icon";
 import { MapBottomNavigation } from "../../../components/map-bottom-navigation";
 import { MapViewport } from "../../../components/map-viewport";
-import { PointOfInterestList } from "../../../components/point-of-interest-list";
 import { WildsideMap } from "../../../components/wildside-map";
 import { waterfrontDiscoveryRoute } from "../../../data/map";
-import { getTagDescriptor } from "../../../data/registries/tags";
-import { pickLocalization } from "../../../domain/entities/localization";
 import { MobileShell } from "../../../layout/mobile-shell";
-import { formatDistance, formatDuration, formatStops } from "../../../units/unit-format";
-import { useUnitPreferences } from "../../../units/unit-preferences-provider";
+import { ItineraryMapHeader } from "./components/itinerary-map-header";
+import { NotesOverlayPanel } from "./components/notes-overlay-panel";
+import { RouteActionButtons } from "./components/route-action-buttons";
+import { RouteSummarySection } from "./components/route-summary-section";
+import { StopsOverlayPanel } from "./components/stops-overlay-panel";
+import { useItineraryData } from "./hooks/use-itinerary-data";
 
 const tabTriggerClass =
   "py-3 text-sm font-semibold text-base-content/70 data-[state=active]:text-accent";
-
-const stickyHandleClass = "mx-auto block h-2 w-12 rounded-full bg-base-300/70";
 
 type MapOverlayProps = TabsContentProps;
 
@@ -31,46 +27,14 @@ function MapOverlay({ className, ...props }: MapOverlayProps): JSX.Element {
   return <Tabs.Content {...props} className={composedClassName} />;
 }
 
-type MapRouteStatProps = {
-  readonly label: string;
-  readonly value: string | number;
-};
-
-function MapRouteStat({ label, value }: MapRouteStatProps): JSX.Element {
-  return (
-    <span className="map-route__stat">
-      <p className="map-route__stat-value">{value}</p>
-      {label}
-    </span>
-  );
-}
-
 export function ItineraryScreen(): JSX.Element {
   const navigate = useNavigate();
-  const { t, i18n } = useTranslation();
-  const { unitSystem } = useUnitPreferences();
-  const unitOptions = useMemo(
-    () => ({ t, locale: i18n.language, unitSystem }),
-    [i18n.language, t, unitSystem],
-  );
-  const distance = formatDistance(waterfrontDiscoveryRoute.distanceMetres, unitOptions);
-  const duration = formatDuration(waterfrontDiscoveryRoute.durationSeconds, {
-    ...unitOptions,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  });
-  const stops = formatStops(waterfrontDiscoveryRoute.stopsCount, {
-    ...unitOptions,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  });
-  const routeCopy = pickLocalization(waterfrontDiscoveryRoute.localizations, i18n.language);
-  const distanceLabel = t("map-itinerary-distance-label", { defaultValue: "Distance" });
-  const durationLabel = t("map-itinerary-duration-label", { defaultValue: "Walking" });
-  const stopsLabel = t("map-itinerary-stops-label", { defaultValue: "Stops" });
-  const [isFavourite, setIsFavourite] = useState(false);
-  const [shareOpen, setShareOpen] = useState(false);
   const [activeTab, setActiveTab] = useState("map");
+  const { language, routeCopy, distance, duration, stops, labels } =
+    useItineraryData(waterfrontDiscoveryRoute);
+
+  const handleBack = () => navigate({ to: "/map/quick" });
+  const handleDismissStops = () => setActiveTab("map");
 
   return (
     <MobileShell tone="dark">
@@ -83,148 +47,36 @@ export function ItineraryScreen(): JSX.Element {
                 gradientClassName="bg-gradient-to-t from-base-900/85 via-base-900/40 to-transparent"
               >
                 <div className="flex flex-col justify-between px-6 pb-6 pt-12">
-                  <div className="flex items-center justify-between">
-                    <button
-                      type="button"
-                      className="circle-action-button--ghost"
-                      aria-label="Back"
-                      onClick={() => navigate({ to: "/map/quick" })}
-                    >
-                      <Icon token="{icon.navigation.back}" aria-hidden className="h-5 w-5" />
-                    </button>
-                    <div className="map-route__meta">
-                      <div className="flex items-center gap-4">
-                        <MapRouteStat
-                          label={distanceLabel}
-                          value={`${distance.value} ${distance.unitLabel}`}
-                        />
-                        <MapRouteStat
-                          label={durationLabel}
-                          value={`${duration.value} ${duration.unitLabel}`}
-                        />
-                        <MapRouteStat
-                          label={stopsLabel}
-                          value={`${stops.value} ${stops.unitLabel}`}
-                        />
-                      </div>
-                    </div>
-                    <button
-                      type="button"
-                      className="circle-action-button--ghost"
-                      aria-label="Locate"
-                    >
-                      <Icon token="{icon.object.locationArrow}" aria-hidden className="h-5 w-5" />
-                    </button>
-                  </div>
+                  <ItineraryMapHeader
+                    distance={distance}
+                    duration={duration}
+                    stops={stops}
+                    labels={labels}
+                    onBack={handleBack}
+                  />
 
                   <div className="mt-auto space-y-4">
-                    <div className="map-route__summary">
-                      <p className="text-sm font-medium text-base-content/60">Suggested route</p>
-                      <h1 className="mt-1 text-2xl font-semibold text-base-content">
-                        {routeCopy.name}
-                      </h1>
-                      <p className="mt-3 text-sm text-base-content/70">{routeCopy.description}</p>
-                      <div className="mt-4 flex flex-wrap gap-2">
-                        {waterfrontDiscoveryRoute.highlightTagIds.map((tagId) => {
-                          const tag = getTagDescriptor(tagId, i18n.language);
-                          const label = tag?.localization.name ?? tagId;
-                          return (
-                            <span key={tagId} className="route-highlight">
-                              {label}
-                            </span>
-                          );
-                        })}
-                      </div>
-                    </div>
-
-                    <div className="flex justify-end gap-3">
-                      <button
-                        type="button"
-                        className={`flex h-10 w-10 items-center justify-center rounded-full border border-base-300/60 transition ${
-                          isFavourite
-                            ? "bg-accent text-base-900"
-                            : "bg-base-200/70 text-base-content"
-                        }`}
-                        aria-label={isFavourite ? "Remove saved itinerary" : "Save this itinerary"}
-                        aria-pressed={isFavourite}
-                        onClick={() => setIsFavourite((prev) => !prev)}
-                      >
-                        <Icon
-                          token={isFavourite ? "{icon.action.like}" : "{icon.action.unlike}"}
-                          aria-hidden
-                        />
-                      </button>
-                      <Dialog.Root open={shareOpen} onOpenChange={setShareOpen}>
-                        <Dialog.Trigger asChild>
-                          <button type="button" className="route-share__trigger">
-                            <Icon token="{icon.action.share}" aria-hidden />
-                            Share
-                          </button>
-                        </Dialog.Trigger>
-                        <Dialog.Portal>
-                          <Dialog.Overlay className="fixed inset-0 bg-black/60" />
-                          <Dialog.Content className="dialog-surface">
-                            <Dialog.Title className="text-lg font-semibold text-base-content">
-                              Share this walk
-                            </Dialog.Title>
-                            <Dialog.Description className="text-sm text-base-content/70">
-                              Copy the preview link or send it to friends once real sharing is wired
-                              up.
-                            </Dialog.Description>
-                            <div className="route-share__preview">
-                              https://wildside.app/routes/{waterfrontDiscoveryRoute.id}
-                            </div>
-                            <div className="flex justify-end gap-2">
-                              <Dialog.Close asChild>
-                                <button type="button" className="btn btn-ghost btn-sm">
-                                  Close
-                                </button>
-                              </Dialog.Close>
-                              <button type="button" className="btn btn-accent btn-sm" disabled>
-                                Coming soon
-                              </button>
-                            </div>
-                          </Dialog.Content>
-                        </Dialog.Portal>
-                      </Dialog.Root>
-                    </div>
+                    <RouteSummarySection
+                      routeName={routeCopy.name}
+                      routeDescription={routeCopy.description}
+                      highlightTagIds={waterfrontDiscoveryRoute.highlightTagIds}
+                      language={language}
+                    />
+                    <RouteActionButtons routeId={waterfrontDiscoveryRoute.id} />
                   </div>
                 </div>
               </MapViewport>
             </MapOverlay>
 
             <MapOverlay value="stops" forceMount>
-              <div className="pointer-events-none px-6 pb-6">
-                <div className="map-panel map-panel--stacked max-h-[60vh]">
-                  <div className="map-panel__handle bg-transparent">
-                    <button
-                      type="button"
-                      className={stickyHandleClass}
-                      aria-label="Dismiss panel"
-                      onClick={() => setActiveTab("map")}
-                    />
-                  </div>
-                  <div className="map-panel__body">
-                    <PointOfInterestList points={waterfrontDiscoveryRoute.pointsOfInterest} />
-                  </div>
-                  <div className="map-overlay__fade map-overlay__fade--top" aria-hidden="true" />
-                  <div className="map-overlay__fade map-overlay__fade--bottom" aria-hidden="true" />
-                </div>
-              </div>
+              <StopsOverlayPanel
+                points={waterfrontDiscoveryRoute.pointsOfInterest}
+                onDismiss={handleDismissStops}
+              />
             </MapOverlay>
 
             <MapOverlay value="notes" forceMount>
-              <div className="pointer-events-none px-6 pb-6">
-                <div className="map-panel map-panel--scroll map-panel__notes">
-                  <p className="text-base font-semibold text-base-content">Route notes</p>
-                  <ul className="mt-3 route-note-list" aria-label="Route notes">
-                    {waterfrontDiscoveryRoute.notes.map((note) => {
-                      const noteCopy = pickLocalization(note.localizations, i18n.language);
-                      return <li key={note.id}>{noteCopy.name}</li>;
-                    })}
-                  </ul>
-                </div>
-              </div>
+              <NotesOverlayPanel notes={waterfrontDiscoveryRoute.notes} language={language} />
             </MapOverlay>
           </div>
 

--- a/src/app/features/map/map-state.tsx
+++ b/src/app/features/map/map-state.tsx
@@ -12,6 +12,8 @@ import {
 } from "react";
 
 import { waterfrontDiscoveryRoute } from "../../data/map";
+import { pickLocalization } from "../../domain/entities/localization";
+import { DEFAULT_LOCALE } from "../../i18n/supported-locales";
 
 type LngLatTuple = [number, number];
 
@@ -81,12 +83,13 @@ const poiData: FeatureCollection<Point, { id: string; name: string }> = {
   type: "FeatureCollection",
   features: waterfrontDiscoveryRoute.pointsOfInterest.map((poi) => {
     const coordinates = poiCoordinates[poi.id] ?? DEFAULT_CENTER;
+    const localization = pickLocalization(poi.localizations, DEFAULT_LOCALE);
     return {
       type: "Feature",
       id: poi.id,
       properties: {
         id: poi.id,
-        name: poi.name,
+        name: localization.name,
       },
       geometry: {
         type: "Point",

--- a/src/app/features/map/saved/hooks/use-route-formatters.ts
+++ b/src/app/features/map/saved/hooks/use-route-formatters.ts
@@ -1,0 +1,32 @@
+/** @file Hook providing memoised formatters and lookups for route display. */
+
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+import { buildDifficultyLookup } from "../../../../data/registries/difficulties";
+
+export type RouteFormatters = {
+  readonly numberFormatter: Intl.NumberFormat;
+  readonly ratingFormatter: Intl.NumberFormat;
+  readonly difficultyLookup: ReturnType<typeof buildDifficultyLookup>;
+};
+
+export const useRouteFormatters = (): RouteFormatters => {
+  const { t, i18n } = useTranslation();
+
+  const numberFormatter = useMemo(() => new Intl.NumberFormat(i18n.language), [i18n.language]);
+  const ratingFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat(i18n.language, {
+        minimumFractionDigits: 1,
+        maximumFractionDigits: 1,
+      }),
+    [i18n.language],
+  );
+  const difficultyLookup = useMemo(() => buildDifficultyLookup(t), [t]);
+
+  return useMemo(
+    () => ({ numberFormatter, ratingFormatter, difficultyLookup }),
+    [numberFormatter, ratingFormatter, difficultyLookup],
+  );
+};

--- a/src/app/features/map/saved/hooks/use-route-formatters.ts
+++ b/src/app/features/map/saved/hooks/use-route-formatters.ts
@@ -11,6 +11,25 @@ export type RouteFormatters = {
   readonly difficultyLookup: ReturnType<typeof buildDifficultyLookup>;
 };
 
+/**
+ * Provides memoised number formatters and difficulty lookup for route display.
+ *
+ * @returns Formatters for numbers, ratings, and a difficulty label lookup map.
+ *
+ * @example
+ * ```tsx
+ * const RouteRating = ({ rating, difficultyId }: Props) => {
+ *   const { ratingFormatter, difficultyLookup } = useRouteFormatters();
+ *   const difficulty = difficultyLookup.get(difficultyId);
+ *
+ *   return (
+ *     <p>
+ *       {ratingFormatter.format(rating)} · {difficulty?.label}
+ *     </p>
+ *   );
+ * };
+ * ```
+ */
 export const useRouteFormatters = (): RouteFormatters => {
   const { t, i18n } = useTranslation();
 

--- a/src/app/features/map/saved/hooks/use-route-metrics.ts
+++ b/src/app/features/map/saved/hooks/use-route-metrics.ts
@@ -1,0 +1,51 @@
+/** @file Hook providing memoised route metrics (distance, duration, stops). */
+
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { WalkRouteSummary } from "../../../../data/map";
+import { formatDistance, formatDuration, formatStops } from "../../../../units/unit-format";
+import { useUnitPreferences } from "../../../../units/unit-preferences-provider";
+
+export type RouteMetrics = {
+  readonly distance: ReturnType<typeof formatDistance>;
+  readonly duration: ReturnType<typeof formatDuration>;
+  readonly stops: ReturnType<typeof formatStops>;
+};
+
+export const useRouteMetrics = (route: WalkRouteSummary): RouteMetrics => {
+  const { t, i18n } = useTranslation();
+  const { unitSystem } = useUnitPreferences();
+
+  const unitOptions = useMemo(
+    () => ({ t, locale: i18n.language, unitSystem }),
+    [i18n.language, t, unitSystem],
+  );
+
+  const distance = useMemo(
+    () => formatDistance(route.distanceMetres, unitOptions),
+    [route.distanceMetres, unitOptions],
+  );
+
+  const duration = useMemo(
+    () =>
+      formatDuration(route.durationSeconds, {
+        ...unitOptions,
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+      }),
+    [route.durationSeconds, unitOptions],
+  );
+
+  const stops = useMemo(
+    () =>
+      formatStops(route.stopsCount, {
+        ...unitOptions,
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+      }),
+    [route.stopsCount, unitOptions],
+  );
+
+  return useMemo(() => ({ distance, duration, stops }), [distance, duration, stops]);
+};

--- a/src/app/features/map/saved/hooks/use-route-metrics.ts
+++ b/src/app/features/map/saved/hooks/use-route-metrics.ts
@@ -13,6 +13,27 @@ export type RouteMetrics = {
   readonly stops: ReturnType<typeof formatStops>;
 };
 
+/**
+ * Provides memoised, formatted route metrics for distance, duration, and stops.
+ *
+ * @param route - The walk route summary containing raw metric values.
+ * @returns Formatted metrics with localised values and unit labels.
+ *
+ * @example
+ * ```tsx
+ * const RouteStats = ({ route }: { route: WalkRouteSummary }) => {
+ *   const { distance, duration, stops } = useRouteMetrics(route);
+ *
+ *   return (
+ *     <p>
+ *       {distance.value} {distance.unitLabel} ·{" "}
+ *       {duration.value} {duration.unitLabel} ·{" "}
+ *       {stops.value} {stops.unitLabel}
+ *     </p>
+ *   );
+ * };
+ * ```
+ */
 export const useRouteMetrics = (route: WalkRouteSummary): RouteMetrics => {
   const { t, i18n } = useTranslation();
   const { unitSystem } = useUnitPreferences();

--- a/src/app/features/map/saved/saved-screen-tabs.tsx
+++ b/src/app/features/map/saved/saved-screen-tabs.tsx
@@ -7,7 +7,7 @@ import type { TFunction } from "i18next";
 import type { JSX, ReactNode } from "react";
 
 import { Icon } from "../../../components/icon";
-import { STICKY_HANDLE_CLASS } from "../../../components/map/map-panel-constants";
+import { DRAGGABLE_HANDLE_CLASS } from "../../../components/map/map-panel-constants";
 import { MapViewport } from "../../../components/map-viewport";
 import { PointOfInterestList } from "../../../components/point-of-interest-list";
 import { WildsideMap } from "../../../components/wildside-map";
@@ -162,7 +162,7 @@ export function StopsTabContent({ savedRoute, onClose, t }: StopsTabContentProps
           <div className="map-panel__handle">
             <button
               type="button"
-              className={STICKY_HANDLE_CLASS}
+              className={DRAGGABLE_HANDLE_CLASS}
               aria-label={t("action-dismiss-panel", { defaultValue: "Dismiss panel" })}
               onClick={onClose}
             />

--- a/src/app/features/map/saved/saved-screen-tabs.tsx
+++ b/src/app/features/map/saved/saved-screen-tabs.tsx
@@ -37,6 +37,12 @@ export function MapOverlay({ className, ...props }: MapOverlayProps): JSX.Elemen
   return <Tabs.Content {...props} className={composedClassName} />;
 }
 
+/**
+ * Displays a single metric value with a label beneath it.
+ *
+ * @param label - The descriptive label for the metric.
+ * @param value - The formatted metric value to display.
+ */
 export function Metric({ label, value }: { label: string; value: string }): JSX.Element {
   return (
     <div className="text-center">

--- a/src/app/features/map/saved/saved-screen-tabs.tsx
+++ b/src/app/features/map/saved/saved-screen-tabs.tsx
@@ -79,7 +79,7 @@ export function MapTabContent({
           <div className="flex items-center justify-between text-base-100">
             <button
               type="button"
-              aria-label="Back"
+              aria-label={t("action-back", { defaultValue: "Back" })}
               className="circle-action-button"
               onClick={onBack}
             >
@@ -87,7 +87,11 @@ export function MapTabContent({
             </button>
             <Dialog.Root open={shareOpen} onOpenChange={onShareOpenChange}>
               <Dialog.Trigger asChild>
-                <button type="button" aria-label="Share" className="circle-action-button">
+                <button
+                  type="button"
+                  aria-label={t("action-share", { defaultValue: "Share" })}
+                  className="circle-action-button"
+                >
                   <Icon token="{icon.action.share}" aria-hidden className="h-5 w-5" />
                 </button>
               </Dialog.Trigger>

--- a/src/app/features/map/saved/saved-screen-tabs.tsx
+++ b/src/app/features/map/saved/saved-screen-tabs.tsx
@@ -11,6 +11,7 @@ import { DRAGGABLE_HANDLE_CLASS } from "../../../components/map/map-panel-consta
 import { MapViewport } from "../../../components/map-viewport";
 import { PointOfInterestList } from "../../../components/point-of-interest-list";
 import { WildsideMap } from "../../../components/wildside-map";
+import { getRouteShareUrl } from "../../../config/route-urls";
 import type { WalkRouteSummary } from "../../../data/map";
 import { getTagDescriptor } from "../../../data/registries/tags";
 import { pickLocalization } from "../../../domain/entities/localization";
@@ -136,9 +137,7 @@ export function MapTabContent({
                         "Sharing is not wired up yet, but this is where the integration will live.",
                     })}
                   </Dialog.Description>
-                  <div className="route-share__preview">
-                    https://wildside.app/routes/{savedRoute.id}
-                  </div>
+                  <div className="route-share__preview">{getRouteShareUrl(savedRoute.id)}</div>
                   <Dialog.Close asChild>
                     <button type="button" className="btn btn-accent btn-sm self-end">
                       {t("action-close", { defaultValue: "Close" })}

--- a/src/app/features/map/saved/saved-screen-tabs.tsx
+++ b/src/app/features/map/saved/saved-screen-tabs.tsx
@@ -221,7 +221,7 @@ export function StopsTabContent({ savedRoute, onClose, t }: StopsTabContentProps
 /**
  * Props for the NotesTabContent component.
  */
-type NotesTabContentProps = {
+export type NotesTabContentProps = {
   readonly savedRoute: WalkRouteSummary;
   readonly routeCopy: SavedRouteData["routeCopy"];
   readonly difficultyLabel: SavedRouteData["difficultyLabel"];

--- a/src/app/features/map/saved/saved-screen-tabs.tsx
+++ b/src/app/features/map/saved/saved-screen-tabs.tsx
@@ -16,11 +16,20 @@ import { getTagDescriptor } from "../../../data/registries/tags";
 import { pickLocalization } from "../../../domain/entities/localization";
 import type { SavedRouteData } from "./use-saved-route-data";
 
+/**
+ * Props for the RouteSummaryMeta component.
+ */
 export type RouteSummaryMetaProps = {
   readonly iconToken: string;
   readonly children: ReactNode;
 };
 
+/**
+ * Renders a route summary metadata item with an icon and content.
+ *
+ * @param iconToken - Design token for the metadata icon.
+ * @param children - Content to display alongside the icon.
+ */
 export function RouteSummaryMeta({ iconToken, children }: RouteSummaryMetaProps): JSX.Element {
   return (
     <span className="route-summary__meta">
@@ -30,8 +39,14 @@ export function RouteSummaryMeta({ iconToken, children }: RouteSummaryMetaProps)
   );
 }
 
+/**
+ * Props for the MapOverlay component (extends Radix Tabs.Content).
+ */
 type MapOverlayProps = TabsContentProps;
 
+/**
+ * Wrapper for Radix Tabs.Content with map-overlay styling.
+ */
 export function MapOverlay({ className, ...props }: MapOverlayProps): JSX.Element {
   const composedClassName = className ? `map-overlay ${className}` : "map-overlay";
   return <Tabs.Content {...props} className={composedClassName} />;
@@ -52,6 +67,9 @@ export function Metric({ label, value }: { label: string; value: string }): JSX.
   );
 }
 
+/**
+ * Props for the MapTabContent component.
+ */
 type MapTabContentProps = {
   readonly savedRoute: WalkRouteSummary;
   readonly routeCopy: SavedRouteData["routeCopy"];
@@ -64,6 +82,11 @@ type MapTabContentProps = {
   readonly onShareOpenChange: (next: boolean) => void;
 };
 
+/**
+ * Renders the map tab content showing route summary, map viewport, and share dialog.
+ *
+ * Displays route name, distance, duration, and stops metadata, with Back and Share actions.
+ */
 export function MapTabContent({
   savedRoute,
   routeCopy,
@@ -158,12 +181,20 @@ export function MapTabContent({
   );
 }
 
+/**
+ * Props for the StopsTabContent component.
+ */
 type StopsTabContentProps = {
   readonly savedRoute: WalkRouteSummary;
   readonly onClose: () => void;
   readonly t: TFunction;
 };
 
+/**
+ * Renders the stops tab content displaying points of interest for the route.
+ *
+ * Shows a dismissible panel with a list of route POIs.
+ */
 export function StopsTabContent({ savedRoute, onClose, t }: StopsTabContentProps): JSX.Element {
   return (
     <MapOverlay value="stops" forceMount>
@@ -188,6 +219,9 @@ export function StopsTabContent({ savedRoute, onClose, t }: StopsTabContentProps
   );
 }
 
+/**
+ * Props for the NotesTabContent component.
+ */
 type NotesTabContentProps = {
   readonly savedRoute: WalkRouteSummary;
   readonly routeCopy: SavedRouteData["routeCopy"];
@@ -199,6 +233,11 @@ type NotesTabContentProps = {
   readonly t: TFunction;
 };
 
+/**
+ * Renders the notes tab content displaying route metrics, highlights, description, and notes.
+ *
+ * Shows rating, saves, difficulty, updated date, highlight tags, route description, and per-language notes.
+ */
 export function NotesTabContent({
   savedRoute,
   routeCopy,

--- a/src/app/features/map/saved/saved-screen-tabs.tsx
+++ b/src/app/features/map/saved/saved-screen-tabs.tsx
@@ -7,6 +7,7 @@ import type { TFunction } from "i18next";
 import type { JSX, ReactNode } from "react";
 
 import { Icon } from "../../../components/icon";
+import { STICKY_HANDLE_CLASS } from "../../../components/map/map-panel-constants";
 import { MapViewport } from "../../../components/map-viewport";
 import { PointOfInterestList } from "../../../components/point-of-interest-list";
 import { WildsideMap } from "../../../components/wildside-map";
@@ -14,8 +15,6 @@ import type { WalkRouteSummary } from "../../../data/map";
 import { getTagDescriptor } from "../../../data/registries/tags";
 import { pickLocalization } from "../../../domain/entities/localization";
 import type { SavedRouteData } from "./use-saved-route-data";
-
-const stickyHandleClass = "mx-auto block h-2 w-12 rounded-full bg-base-300/70";
 
 export type RouteSummaryMetaProps = {
   readonly iconToken: string;
@@ -96,17 +95,20 @@ export function MapTabContent({
                 <Dialog.Overlay className="fixed inset-0 bg-black/60" />
                 <Dialog.Content className="dialog-surface">
                   <Dialog.Title className="text-lg font-semibold text-base-content">
-                    Share saved walk
+                    {t("map-saved-share-title", { defaultValue: "Share saved walk" })}
                   </Dialog.Title>
                   <Dialog.Description className="text-sm text-base-content/70">
-                    Sharing is not wired up yet, but this is where the integration will live.
+                    {t("map-saved-share-description", {
+                      defaultValue:
+                        "Sharing is not wired up yet, but this is where the integration will live.",
+                    })}
                   </Dialog.Description>
                   <div className="route-share__preview">
                     https://wildside.app/routes/{savedRoute.id}
                   </div>
                   <Dialog.Close asChild>
                     <button type="button" className="btn btn-accent btn-sm self-end">
-                      Close
+                      {t("action-close", { defaultValue: "Close" })}
                     </button>
                   </Dialog.Close>
                 </Dialog.Content>
@@ -149,9 +151,10 @@ export function MapTabContent({
 type StopsTabContentProps = {
   readonly savedRoute: WalkRouteSummary;
   readonly onClose: () => void;
+  readonly t: TFunction;
 };
 
-export function StopsTabContent({ savedRoute, onClose }: StopsTabContentProps): JSX.Element {
+export function StopsTabContent({ savedRoute, onClose, t }: StopsTabContentProps): JSX.Element {
   return (
     <MapOverlay value="stops" forceMount>
       <div className="pointer-events-none px-6 pb-6">
@@ -159,8 +162,8 @@ export function StopsTabContent({ savedRoute, onClose }: StopsTabContentProps): 
           <div className="map-panel__handle">
             <button
               type="button"
-              className={stickyHandleClass}
-              aria-label="Dismiss panel"
+              className={STICKY_HANDLE_CLASS}
+              aria-label={t("action-dismiss-panel", { defaultValue: "Dismiss panel" })}
               onClick={onClose}
             />
           </div>
@@ -183,6 +186,7 @@ type NotesTabContentProps = {
   readonly numberFormatter: SavedRouteData["numberFormatter"];
   readonly ratingFormatter: SavedRouteData["ratingFormatter"];
   readonly i18nLanguage: string;
+  readonly t: TFunction;
 };
 
 export function NotesTabContent({
@@ -193,16 +197,29 @@ export function NotesTabContent({
   numberFormatter,
   ratingFormatter,
   i18nLanguage,
+  t,
 }: NotesTabContentProps): JSX.Element {
   return (
     <MapOverlay value="notes" forceMount>
       <div className="pointer-events-none px-6 pb-6">
         <div className="map-panel map-panel--scroll map-panel__notes map-panel__notes--spacious">
           <div className="grid grid-cols-4 gap-4 text-base-content">
-            <Metric label="Rating" value={ratingFormatter.format(savedRoute.rating)} />
-            <Metric label="Saves" value={numberFormatter.format(savedRoute.saves)} />
-            <Metric label="Difficulty" value={difficultyLabel} />
-            <Metric label="Updated" value={updatedLabel} />
+            <Metric
+              label={t("saved-route-metric-rating", { defaultValue: "Rating" })}
+              value={ratingFormatter.format(savedRoute.rating)}
+            />
+            <Metric
+              label={t("saved-route-metric-saves", { defaultValue: "Saves" })}
+              value={numberFormatter.format(savedRoute.saves)}
+            />
+            <Metric
+              label={t("saved-route-metric-difficulty", { defaultValue: "Difficulty" })}
+              value={difficultyLabel}
+            />
+            <Metric
+              label={t("saved-route-metric-updated", { defaultValue: "Updated" })}
+              value={updatedLabel}
+            />
           </div>
           <div className="flex flex-wrap gap-2">
             {savedRoute.highlightTagIds.map((tagId) => {
@@ -216,7 +233,10 @@ export function NotesTabContent({
             })}
           </div>
           <p className="text-base-content/80">{routeCopy.description}</p>
-          <ul className="route-note-list" aria-label="Route notes">
+          <ul
+            className="route-note-list"
+            aria-label={t("saved-route-notes-label", { defaultValue: "Route notes" })}
+          >
             {savedRoute.notes.map((note) => {
               const noteCopy = pickLocalization(note.localizations, i18nLanguage);
               return <li key={note.id}>{noteCopy.name}</li>;

--- a/src/app/features/map/saved/saved-screen.tsx
+++ b/src/app/features/map/saved/saved-screen.tsx
@@ -71,7 +71,7 @@ function SavedScreenWithRoute({ savedRoute }: SavedScreenWithRouteProps): JSX.El
               onShareOpenChange={setShareOpen}
             />
 
-            <StopsTabContent savedRoute={savedRoute} onClose={() => setActiveTab("map")} />
+            <StopsTabContent savedRoute={savedRoute} onClose={() => setActiveTab("map")} t={t} />
 
             <NotesTabContent
               savedRoute={savedRoute}
@@ -81,6 +81,7 @@ function SavedScreenWithRoute({ savedRoute }: SavedScreenWithRouteProps): JSX.El
               numberFormatter={numberFormatter}
               ratingFormatter={ratingFormatter}
               i18nLanguage={i18n.language}
+              t={t}
             />
           </div>
 

--- a/src/app/features/map/saved/saved-screen.tsx
+++ b/src/app/features/map/saved/saved-screen.tsx
@@ -2,7 +2,7 @@
 
 import * as Tabs from "@radix-ui/react-tabs";
 import { useNavigate } from "@tanstack/react-router";
-import { type JSX, useState } from "react";
+import { type JSX, useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Icon } from "../../../components/icon";
@@ -43,6 +43,9 @@ function SavedScreenWithRoute({ savedRoute }: SavedScreenWithRouteProps): JSX.El
   const [shareOpen, setShareOpen] = useState(false);
   const [activeTab, setActiveTab] = useState("map");
 
+  const handleBack = useCallback(() => navigate({ to: "/map/quick" }), [navigate]);
+  const handleDismissStops = useCallback(() => setActiveTab("map"), []);
+
   const {
     routeCopy,
     distance,
@@ -66,12 +69,12 @@ function SavedScreenWithRoute({ savedRoute }: SavedScreenWithRouteProps): JSX.El
               duration={duration}
               stops={stops}
               t={t}
-              onBack={() => navigate({ to: "/map/quick" })}
+              onBack={handleBack}
               shareOpen={shareOpen}
               onShareOpenChange={setShareOpen}
             />
 
-            <StopsTabContent savedRoute={savedRoute} onClose={() => setActiveTab("map")} t={t} />
+            <StopsTabContent savedRoute={savedRoute} onClose={handleDismissStops} t={t} />
 
             <NotesTabContent
               savedRoute={savedRoute}

--- a/src/app/features/map/saved/saved-screen.tsx
+++ b/src/app/features/map/saved/saved-screen.tsx
@@ -1,84 +1,22 @@
 /** @file Saved walk detail screen with MapLibre map and tabbed layout. */
 
-import * as Dialog from "@radix-ui/react-dialog";
-import type { TabsContentProps } from "@radix-ui/react-tabs";
 import * as Tabs from "@radix-ui/react-tabs";
 import { useNavigate } from "@tanstack/react-router";
-import { type JSX, type ReactNode, useMemo, useState } from "react";
+import { type JSX, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Icon } from "../../../components/icon";
 import { MapBottomNavigation } from "../../../components/map-bottom-navigation";
-import { MapViewport } from "../../../components/map-viewport";
-import { PointOfInterestList } from "../../../components/point-of-interest-list";
-import { WildsideMap } from "../../../components/wildside-map";
 import { savedRoutes } from "../../../data/map";
-import { buildDifficultyLookup } from "../../../data/registries/difficulties";
-import { getTagDescriptor } from "../../../data/registries/tags";
-import { pickLocalization } from "../../../domain/entities/localization";
 import { MobileShell } from "../../../layout/mobile-shell";
-import { formatRelativeTime } from "../../../lib/relative-time";
-import { formatDistance, formatDuration, formatStops } from "../../../units/unit-format";
-import { useUnitPreferences } from "../../../units/unit-preferences-provider";
+import { MapTabContent, NotesTabContent, StopsTabContent } from "./saved-screen-tabs";
+import { useSavedRouteData } from "./use-saved-route-data";
 
 const savedRoute = savedRoutes[0];
 const tabTriggerClass =
   "py-3 text-sm font-semibold text-base-content/70 data-[state=active]:text-accent";
 
-const stickyHandleClass = "mx-auto block h-2 w-12 rounded-full bg-base-300/70";
-
-type RouteSummaryMetaProps = {
-  readonly iconToken: string;
-  readonly children: ReactNode;
-};
-
-function RouteSummaryMeta({ iconToken, children }: RouteSummaryMetaProps): JSX.Element {
-  return (
-    <span className="route-summary__meta">
-      <Icon token={iconToken} className="text-accent" aria-hidden />
-      {children}
-    </span>
-  );
-}
-
-type MapOverlayProps = TabsContentProps;
-
-function MapOverlay({ className, ...props }: MapOverlayProps): JSX.Element {
-  const composedClassName = className ? `map-overlay ${className}` : "map-overlay";
-  return <Tabs.Content {...props} className={composedClassName} />;
-}
-
-function Metric({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="text-center">
-      <p className="text-lg font-semibold text-base-content">{value}</p>
-      <p className="text-xs text-base-content/60">{label}</p>
-    </div>
-  );
-}
-
 export function SavedScreen(): JSX.Element {
-  const navigate = useNavigate();
-  const { t, i18n } = useTranslation();
-  const { unitSystem } = useUnitPreferences();
-  const [isFavourite, setIsFavourite] = useState(true);
-  const [shareOpen, setShareOpen] = useState(false);
-  const [activeTab, setActiveTab] = useState("map");
-  const numberFormatter = useMemo(() => new Intl.NumberFormat(i18n.language), [i18n.language]);
-  const ratingFormatter = useMemo(
-    () =>
-      new Intl.NumberFormat(i18n.language, {
-        minimumFractionDigits: 1,
-        maximumFractionDigits: 1,
-      }),
-    [i18n.language],
-  );
-  const difficultyLookup = useMemo(() => buildDifficultyLookup(t), [t]);
-  const unitOptions = useMemo(
-    () => ({ t, locale: i18n.language, unitSystem }),
-    [i18n.language, t, unitSystem],
-  );
-
   if (!savedRoute) {
     return (
       <MobileShell tone="dark">
@@ -91,152 +29,59 @@ export function SavedScreen(): JSX.Element {
     );
   }
 
-  const routeCopy = pickLocalization(savedRoute.localizations, i18n.language);
-  const difficultyLabel =
-    difficultyLookup.get(savedRoute.difficultyId)?.label ?? savedRoute.difficultyId;
-  const updatedLabel = formatRelativeTime(savedRoute.lastUpdatedAt, i18n.language);
+  return <SavedScreenWithRoute savedRoute={savedRoute} />;
+}
 
-  const distance = formatDistance(savedRoute.distanceMetres, unitOptions);
-  const duration = formatDuration(savedRoute.durationSeconds, {
-    ...unitOptions,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  });
-  const stops = formatStops(savedRoute.stopsCount, {
-    ...unitOptions,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  });
+type SavedScreenWithRouteProps = {
+  readonly savedRoute: NonNullable<typeof savedRoute>;
+};
+
+function SavedScreenWithRoute({ savedRoute }: SavedScreenWithRouteProps): JSX.Element {
+  const navigate = useNavigate();
+  const { t, i18n } = useTranslation();
+  const [isFavourite, setIsFavourite] = useState(true);
+  const [shareOpen, setShareOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState("map");
+
+  const {
+    routeCopy,
+    distance,
+    duration,
+    stops,
+    difficultyLabel,
+    updatedLabel,
+    numberFormatter,
+    ratingFormatter,
+  } = useSavedRouteData(savedRoute);
 
   return (
     <MobileShell tone="dark">
       <main className="map-shell__main">
         <Tabs.Root value={activeTab} onValueChange={setActiveTab} className="map-shell__pane">
           <div className="map-shell__viewport">
-            <MapOverlay value="map" forceMount>
-              <MapViewport
-                map={<WildsideMap />}
-                gradientClassName="bg-gradient-to-t from-base-900/80 via-base-900/30 to-transparent"
-              >
-                <div className="flex flex-col justify-between px-6 pb-6 pt-8">
-                  <div className="flex items-center justify-between text-base-100">
-                    <button
-                      type="button"
-                      aria-label="Back"
-                      className="circle-action-button"
-                      onClick={() => navigate({ to: "/map/quick" })}
-                    >
-                      <Icon token="{icon.navigation.back}" aria-hidden className="h-5 w-5" />
-                    </button>
-                    <Dialog.Root open={shareOpen} onOpenChange={setShareOpen}>
-                      <Dialog.Trigger asChild>
-                        <button type="button" aria-label="Share" className="circle-action-button">
-                          <Icon token="{icon.action.share}" aria-hidden className="h-5 w-5" />
-                        </button>
-                      </Dialog.Trigger>
-                      <Dialog.Portal>
-                        <Dialog.Overlay className="fixed inset-0 bg-black/60" />
-                        <Dialog.Content className="dialog-surface">
-                          <Dialog.Title className="text-lg\ font-semibold text-base-content">
-                            Share saved walk
-                          </Dialog.Title>
-                          <Dialog.Description className="text-sm text-base-content/70">
-                            Sharing is not wired up yet, but this is where the integration will
-                            live.
-                          </Dialog.Description>
-                          <div className="route-share__preview">
-                            https://wildside.app/routes/{savedRoute.id}
-                          </div>
-                          <Dialog.Close asChild>
-                            <button type="button" className="btn btn-accent btn-sm self-end">
-                              Close
-                            </button>
-                          </Dialog.Close>
-                        </Dialog.Content>
-                      </Dialog.Portal>
-                    </Dialog.Root>
-                  </div>
+            <MapTabContent
+              savedRoute={savedRoute}
+              routeCopy={routeCopy}
+              distance={distance}
+              duration={duration}
+              stops={stops}
+              t={t}
+              onBack={() => navigate({ to: "/map/quick" })}
+              shareOpen={shareOpen}
+              onShareOpenChange={setShareOpen}
+            />
 
-                  <div className="mt-auto saved-summary__panel">
-                    <h1 className="text-2xl font-semibold">{routeCopy.name}</h1>
-                    <div className="mt-2 flex flex-wrap items-center gap-3 text-sm text-base-content/70">
-                      <RouteSummaryMeta iconToken="{icon.object.route}">
-                        {t("saved-route-distance-value", {
-                          value: distance.value,
-                          unit: distance.unitLabel,
-                          defaultValue: `${distance.value} ${distance.unitLabel}`,
-                        })}
-                      </RouteSummaryMeta>
-                      <RouteSummaryMeta iconToken="{icon.object.duration}">
-                        {t("saved-route-duration-value", {
-                          value: duration.value,
-                          unit: duration.unitLabel,
-                          defaultValue: `${duration.value} ${duration.unitLabel}`,
-                        })}
-                      </RouteSummaryMeta>
-                      <RouteSummaryMeta iconToken="{icon.object.stops}">
-                        {t("saved-route-stops-value", {
-                          value: stops.value,
-                          unit: stops.unitLabel,
-                          defaultValue: `${stops.value} ${stops.unitLabel}`,
-                        })}
-                      </RouteSummaryMeta>
-                    </div>
-                  </div>
-                </div>
-              </MapViewport>
-            </MapOverlay>
+            <StopsTabContent savedRoute={savedRoute} onClose={() => setActiveTab("map")} />
 
-            <MapOverlay value="stops" forceMount>
-              <div className="pointer-events-none px-6 pb-6">
-                <div className="map-panel map-panel--stacked max-h-[60vh]">
-                  <div className="map-panel__handle">
-                    <button
-                      type="button"
-                      className={stickyHandleClass}
-                      aria-label="Dismiss panel"
-                      onClick={() => setActiveTab("map")}
-                    />
-                  </div>
-                  <div className="map-panel__body">
-                    <PointOfInterestList points={savedRoute.pointsOfInterest} />
-                  </div>
-                  <div className="map-overlay__fade map-overlay__fade--top" aria-hidden="true" />
-                  <div className="map-overlay__fade map-overlay__fade--bottom" aria-hidden="true" />
-                </div>
-              </div>
-            </MapOverlay>
-
-            <MapOverlay value="notes" forceMount>
-              <div className="pointer-events-none px-6 pb-6">
-                <div className="map-panel map-panel--scroll map-panel__notes map-panel__notes--spacious">
-                  <div className="grid grid-cols-4 gap-4 text-base-content">
-                    <Metric label="Rating" value={ratingFormatter.format(savedRoute.rating)} />
-                    <Metric label="Saves" value={numberFormatter.format(savedRoute.saves)} />
-                    <Metric label="Difficulty" value={difficultyLabel} />
-                    <Metric label="Updated" value={updatedLabel} />
-                  </div>
-                  <div className="flex flex-wrap gap-2">
-                    {savedRoute.highlightTagIds.map((tagId) => {
-                      const tag = getTagDescriptor(tagId, i18n.language);
-                      const label = tag?.localization.name ?? tagId;
-                      return (
-                        <span key={tagId} className="route-highlight">
-                          {label}
-                        </span>
-                      );
-                    })}
-                  </div>
-                  <p className="text-base-content/80">{routeCopy.description}</p>
-                  <ul className="route-note-list" aria-label="Route notes">
-                    {savedRoute.notes.map((note) => {
-                      const noteCopy = pickLocalization(note.localizations, i18n.language);
-                      return <li key={note.id}>{noteCopy.name}</li>;
-                    })}
-                  </ul>
-                </div>
-              </div>
-            </MapOverlay>
+            <NotesTabContent
+              savedRoute={savedRoute}
+              routeCopy={routeCopy}
+              difficultyLabel={difficultyLabel}
+              updatedLabel={updatedLabel}
+              numberFormatter={numberFormatter}
+              ratingFormatter={ratingFormatter}
+              i18nLanguage={i18n.language}
+            />
           </div>
 
           <Tabs.List className="map-panel__tablist">

--- a/src/app/features/map/saved/use-saved-route-data.ts
+++ b/src/app/features/map/saved/use-saved-route-data.ts
@@ -16,6 +16,39 @@ export type SavedRouteData = RouteFormatters &
     readonly updatedLabel: string;
   };
 
+/**
+ * Prepare formatted and localised data for presenting a saved route.
+ *
+ * @param route - The walk route summary to format.
+ * @returns Localised route copy, formatted metrics, and route-related labels.
+ *
+ * @example
+ * ```tsx
+ * const SavedRouteCard = ({ route }: { route: WalkRouteSummary }) => {
+ *   const {
+ *     routeCopy,
+ *     distance,
+ *     duration,
+ *     difficultyLabel,
+ *     updatedLabel,
+ *   } = useSavedRouteData(route);
+ *
+ *   return (
+ *     <article>
+ *       <h2>{routeCopy.name}</h2>
+ *       <p>{routeCopy.description}</p>
+ *       <p>
+ *         {distance.value} {distance.unitLabel} ·{" "}
+ *         {duration.value} {duration.unitLabel}
+ *       </p>
+ *       <p>
+ *         {difficultyLabel} · {updatedLabel}
+ *       </p>
+ *     </article>
+ *   );
+ * };
+ * ```
+ */
 export const useSavedRouteData = (route: WalkRouteSummary): SavedRouteData => {
   const { i18n } = useTranslation();
   const formatters = useRouteFormatters();

--- a/src/app/features/map/saved/use-saved-route-data.ts
+++ b/src/app/features/map/saved/use-saved-route-data.ts
@@ -1,0 +1,72 @@
+/** @file Hook to prepare formatted and localised data for a saved route. */
+
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { WalkRouteSummary } from "../../../data/map";
+import { buildDifficultyLookup } from "../../../data/registries/difficulties";
+import { pickLocalization } from "../../../domain/entities/localization";
+import { formatRelativeTime } from "../../../lib/relative-time";
+import { formatDistance, formatDuration, formatStops } from "../../../units/unit-format";
+import { useUnitPreferences } from "../../../units/unit-preferences-provider";
+
+export type SavedRouteData = {
+  readonly routeCopy: ReturnType<typeof pickLocalization>;
+  readonly difficultyLabel: string;
+  readonly updatedLabel: string;
+  readonly distance: ReturnType<typeof formatDistance>;
+  readonly duration: ReturnType<typeof formatDuration>;
+  readonly stops: ReturnType<typeof formatStops>;
+  readonly numberFormatter: Intl.NumberFormat;
+  readonly ratingFormatter: Intl.NumberFormat;
+  readonly difficultyLookup: ReturnType<typeof buildDifficultyLookup>;
+};
+
+export const useSavedRouteData = (route: WalkRouteSummary): SavedRouteData => {
+  const { t, i18n } = useTranslation();
+  const { unitSystem } = useUnitPreferences();
+
+  const numberFormatter = useMemo(() => new Intl.NumberFormat(i18n.language), [i18n.language]);
+  const ratingFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat(i18n.language, {
+        minimumFractionDigits: 1,
+        maximumFractionDigits: 1,
+      }),
+    [i18n.language],
+  );
+  const difficultyLookup = useMemo(() => buildDifficultyLookup(t), [t]);
+
+  const unitOptions = useMemo(
+    () => ({ t, locale: i18n.language, unitSystem }),
+    [i18n.language, t, unitSystem],
+  );
+
+  const routeCopy = pickLocalization(route.localizations, i18n.language);
+  const difficultyLabel = difficultyLookup.get(route.difficultyId)?.label ?? route.difficultyId;
+  const updatedLabel = formatRelativeTime(route.lastUpdatedAt, i18n.language);
+
+  const distance = formatDistance(route.distanceMetres, unitOptions);
+  const duration = formatDuration(route.durationSeconds, {
+    ...unitOptions,
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  });
+  const stops = formatStops(route.stopsCount, {
+    ...unitOptions,
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  });
+
+  return {
+    routeCopy,
+    difficultyLabel,
+    updatedLabel,
+    distance,
+    duration,
+    stops,
+    numberFormatter,
+    ratingFormatter,
+    difficultyLookup,
+  };
+};

--- a/src/app/features/map/saved/use-saved-route-data.ts
+++ b/src/app/features/map/saved/use-saved-route-data.ts
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import type { WalkRouteSummary } from "../../../data/map";
 import { pickLocalization } from "../../../domain/entities/localization";
 import { formatRelativeTime } from "../../../lib/relative-time";
+import { getNow } from "../../../lib/time";
 import { type RouteFormatters, useRouteFormatters } from "./hooks/use-route-formatters";
 import { type RouteMetrics, useRouteMetrics } from "./hooks/use-route-metrics";
 
@@ -65,7 +66,7 @@ export const useSavedRouteData = (route: WalkRouteSummary): SavedRouteData => {
   );
 
   const updatedLabel = useMemo(
-    () => formatRelativeTime(route.lastUpdatedAt, i18n.language),
+    () => formatRelativeTime(route.lastUpdatedAt, i18n.language, getNow()),
     [route.lastUpdatedAt, i18n.language],
   );
 

--- a/src/app/features/map/saved/use-saved-route-data.ts
+++ b/src/app/features/map/saved/use-saved-route-data.ts
@@ -82,15 +82,28 @@ export const useSavedRouteData = (route: WalkRouteSummary): SavedRouteData => {
     [route.stopsCount, unitOptions],
   );
 
-  return {
-    routeCopy,
-    difficultyLabel,
-    updatedLabel,
-    distance,
-    duration,
-    stops,
-    numberFormatter,
-    ratingFormatter,
-    difficultyLookup,
-  };
+  return useMemo(
+    () => ({
+      routeCopy,
+      difficultyLabel,
+      updatedLabel,
+      distance,
+      duration,
+      stops,
+      numberFormatter,
+      ratingFormatter,
+      difficultyLookup,
+    }),
+    [
+      routeCopy,
+      difficultyLabel,
+      updatedLabel,
+      distance,
+      duration,
+      stops,
+      numberFormatter,
+      ratingFormatter,
+      difficultyLookup,
+    ],
+  );
 };

--- a/src/app/features/map/saved/use-saved-route-data.ts
+++ b/src/app/features/map/saved/use-saved-route-data.ts
@@ -42,21 +42,45 @@ export const useSavedRouteData = (route: WalkRouteSummary): SavedRouteData => {
     [i18n.language, t, unitSystem],
   );
 
-  const routeCopy = pickLocalization(route.localizations, i18n.language);
-  const difficultyLabel = difficultyLookup.get(route.difficultyId)?.label ?? route.difficultyId;
-  const updatedLabel = formatRelativeTime(route.lastUpdatedAt, i18n.language);
+  const routeCopy = useMemo(
+    () => pickLocalization(route.localizations, i18n.language),
+    [route.localizations, i18n.language],
+  );
 
-  const distance = formatDistance(route.distanceMetres, unitOptions);
-  const duration = formatDuration(route.durationSeconds, {
-    ...unitOptions,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  });
-  const stops = formatStops(route.stopsCount, {
-    ...unitOptions,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  });
+  const difficultyLabel = useMemo(
+    () => difficultyLookup.get(route.difficultyId)?.label ?? route.difficultyId,
+    [route.difficultyId, difficultyLookup],
+  );
+
+  const updatedLabel = useMemo(
+    () => formatRelativeTime(route.lastUpdatedAt, i18n.language),
+    [route.lastUpdatedAt, i18n.language],
+  );
+
+  const distance = useMemo(
+    () => formatDistance(route.distanceMetres, unitOptions),
+    [route.distanceMetres, unitOptions],
+  );
+
+  const duration = useMemo(
+    () =>
+      formatDuration(route.durationSeconds, {
+        ...unitOptions,
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+      }),
+    [route.durationSeconds, unitOptions],
+  );
+
+  const stops = useMemo(
+    () =>
+      formatStops(route.stopsCount, {
+        ...unitOptions,
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+      }),
+    [route.stopsCount, unitOptions],
+  );
 
   return {
     routeCopy,

--- a/src/app/features/offline/components/offline-auto-management.tsx
+++ b/src/app/features/offline/components/offline-auto-management.tsx
@@ -52,7 +52,10 @@ export function OfflineAutoManagement({
                   days: retentionLabel,
                   defaultValue: `Remove maps after ${retentionLabel}`,
                 })
-              : "");
+              : t("offline-auto-option-generic-description", {
+                  name: optionLocalization.name,
+                  defaultValue: `Enable ${optionLocalization.name}`,
+                }));
           return (
             <PreferenceToggleCard
               key={option.id}

--- a/src/app/features/offline/components/offline-auto-management.tsx
+++ b/src/app/features/offline/components/offline-auto-management.tsx
@@ -1,0 +1,72 @@
+/** @file Auto-management settings list for offline downloads. */
+
+import type { TFunction } from "i18next";
+import type { JSX } from "react";
+
+import { Icon } from "../../../components/icon";
+import { PreferenceToggleCard } from "../../../components/preference-toggle-card";
+import type { AutoManagementOption } from "../../../data/stage-four";
+import { pickLocalization } from "../../../domain/entities/localization";
+
+type OfflineAutoManagementProps = {
+  readonly autoHeading: string;
+  readonly autoManagementOptions: AutoManagementOption[];
+  readonly autoSettings: Record<string, boolean>;
+  readonly onToggle: (id: string, next: boolean) => void;
+  readonly integerFormatter: Intl.NumberFormat;
+  readonly i18nLanguage: string;
+  readonly t: TFunction;
+};
+
+export function OfflineAutoManagement({
+  autoHeading,
+  autoManagementOptions,
+  autoSettings,
+  onToggle,
+  integerFormatter,
+  i18nLanguage,
+  t,
+}: OfflineAutoManagementProps): JSX.Element {
+  return (
+    <section className="space-y-4">
+      <header className="flex items-center gap-3">
+        <Icon token="{icon.action.settings}" className="text-accent" aria-hidden />
+        <h2 className="text-base font-semibold text-base-content">{autoHeading}</h2>
+      </header>
+      <div className="space-y-4">
+        {autoManagementOptions.map((option) => {
+          const checked = autoSettings[option.id] ?? option.defaultEnabled;
+          const optionLocalization = pickLocalization(option.localizations, i18nLanguage);
+          const retentionLabel =
+            option.retentionDays != null
+              ? t("offline-auto-option-retention", {
+                  count: option.retentionDays,
+                  days: integerFormatter.format(option.retentionDays),
+                  defaultValue: `${integerFormatter.format(option.retentionDays)} days`,
+                })
+              : null;
+          const optionDescription =
+            optionLocalization.description ??
+            (retentionLabel
+              ? t("offline-auto-option-auto-delete-description", {
+                  days: retentionLabel,
+                  defaultValue: `Remove maps after ${retentionLabel}`,
+                })
+              : "");
+          return (
+            <PreferenceToggleCard
+              key={option.id}
+              id={`auto-management-${option.id}`}
+              iconToken={option.iconToken}
+              iconClassName={option.iconClassName}
+              title={optionLocalization.name}
+              description={optionDescription}
+              isChecked={Boolean(checked)}
+              onCheckedChange={(value) => onToggle(option.id, value)}
+            />
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/app/features/offline/components/offline-download-card.tsx
+++ b/src/app/features/offline/components/offline-download-card.tsx
@@ -1,0 +1,152 @@
+/** @file Download and undo cards for offline map areas. */
+
+import type { TFunction } from "i18next";
+import type { JSX, ReactNode } from "react";
+
+import { Icon } from "../../../components/icon";
+import type { OfflineMapArea } from "../../../data/stage-four";
+
+export type DownloadEntry =
+  | { kind: "download"; area: OfflineMapArea }
+  | { kind: "undo"; area: OfflineMapArea };
+
+export type DownloadStatusLabels = {
+  statusCompleteLabel: string;
+  statusUpdatingLabel: string;
+  statusDownloadingLabel: string;
+};
+
+type FormatAreaCopy = (area: OfflineMapArea) => {
+  readonly localization: { name: string; description?: string };
+  readonly sizeLabel: string;
+  readonly updatedLabel: string;
+};
+
+type OfflineDownloadMetaComponent = (props: {
+  readonly as?: "p" | "span" | "div";
+  readonly className?: string;
+  readonly children: ReactNode;
+}) => JSX.Element;
+
+type OfflineDownloadCardProps = {
+  readonly entry: DownloadEntry;
+  readonly isManaging: boolean;
+  readonly statusLabels: DownloadStatusLabels;
+  readonly formatAreaCopy: FormatAreaCopy;
+  readonly percentFormatter: Intl.NumberFormat;
+  readonly undoDescription: string;
+  readonly undoDescriptionDefault: string;
+  readonly undoButtonLabel: string;
+  readonly MetaComponent: OfflineDownloadMetaComponent;
+  readonly renderStatusBadge: (
+    status: OfflineMapArea["status"],
+    labels: DownloadStatusLabels,
+  ) => JSX.Element | null;
+  readonly onDelete: (downloadId: string) => void;
+  readonly onUndo: (downloadId: string) => void;
+  readonly t: TFunction;
+};
+
+export function OfflineDownloadCard({
+  entry,
+  isManaging,
+  statusLabels,
+  formatAreaCopy,
+  percentFormatter,
+  undoDescription,
+  undoDescriptionDefault,
+  undoButtonLabel,
+  MetaComponent,
+  renderStatusBadge,
+  onDelete,
+  onUndo,
+  t,
+}: OfflineDownloadCardProps): JSX.Element {
+  const area = entry.area;
+  const { localization, sizeLabel, updatedLabel } = formatAreaCopy(area);
+  const progressPercent = percentFormatter.format(area.progress);
+
+  if (entry.kind === "undo") {
+    return (
+      <article
+        key={`${area.id}-undo`}
+        data-testid="offline-undo-card"
+        className="offline-download__undo"
+        aria-label={t("offline-downloads-undo-aria", {
+          title: localization.name,
+          description: undoDescriptionDefault,
+          defaultValue: "{{title}} deleted. {{description}}",
+        })}
+      >
+        <div>
+          <p className="font-semibold">
+            {t("offline-downloads-undo-title", {
+              title: localization.name,
+              defaultValue: `${localization.name} deleted`,
+            })}
+          </p>
+          <MetaComponent>{undoDescription}</MetaComponent>
+        </div>
+        <button
+          type="button"
+          className="btn btn-sm btn-ghost"
+          onClick={() => onUndo(area.id)}
+          data-testid="offline-undo-button"
+        >
+          {undoButtonLabel}
+        </button>
+      </article>
+    );
+  }
+
+  return (
+    <article
+      key={area.id}
+      data-testid="offline-download-card"
+      className="offline-download__card"
+      aria-labelledby={`${area.id}-title`}
+    >
+      {isManaging ? (
+        <button
+          type="button"
+          data-testid="offline-delete-button"
+          aria-label={t("offline-downloads-delete-aria", {
+            title: localization.name,
+            defaultValue: `Delete ${localization.name}`,
+          })}
+          className="offline-download__dismiss"
+          onClick={() => onDelete(area.id)}
+        >
+          <Icon token="{icon.action.remove}" className="text-lg" aria-hidden />
+        </button>
+      ) : null}
+      <img
+        src={area.image.url}
+        alt={area.image.alt}
+        className="h-16 w-16 flex-shrink-0 rounded-xl object-cover"
+      />
+      <div className="flex-1">
+        <div className="split-row">
+          <div>
+            <h3 id={`${area.id}-title`} className="font-semibold text-base-content">
+              {localization.name}
+            </h3>
+            <MetaComponent>
+              {updatedLabel} • {sizeLabel}
+            </MetaComponent>
+          </div>
+          {renderStatusBadge(area.status, statusLabels)}
+        </div>
+        <div className="mt-2 flex items-center gap-3">
+          <div className="h-1.5 flex-1 rounded-full bg-base-300/60">
+            <div
+              className={`h-1.5 rounded-full ${area.status === "downloading" ? "bg-amber-400" : "bg-accent"}`}
+              style={{ width: `${Math.round(area.progress * 100)}%` }}
+            />
+          </div>
+          <MetaComponent as="span">{progressPercent}</MetaComponent>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/app/features/offline/components/offline-download-card.tsx
+++ b/src/app/features/offline/components/offline-download-card.tsx
@@ -22,13 +22,13 @@ export type OfflineDownloadMetaProps = {
   readonly children: ReactNode;
 };
 
-type FormatAreaCopy = (area: OfflineMapArea) => {
+export type FormatAreaCopy = (area: OfflineMapArea) => {
   readonly localization: { name: string; description?: string };
   readonly sizeLabel: string;
   readonly updatedLabel: string;
 };
 
-type OfflineDownloadMetaComponent = (props: OfflineDownloadMetaProps) => JSX.Element;
+export type OfflineDownloadMetaComponent = (props: OfflineDownloadMetaProps) => JSX.Element;
 
 type OfflineDownloadCardProps = {
   readonly entry: DownloadEntry;

--- a/src/app/features/offline/components/offline-download-card.tsx
+++ b/src/app/features/offline/components/offline-download-card.tsx
@@ -66,12 +66,13 @@ export function OfflineDownloadCard({
 }: OfflineDownloadCardProps): JSX.Element {
   const area = entry.area;
   const { localization, sizeLabel, updatedLabel } = formatAreaCopy(area);
-  const progressPercent = percentFormatter.format(area.progress);
+  // Clamp progress to valid percentage bounds (0-100%)
+  const clampedProgress = Math.max(0, Math.min(1, area.progress));
+  const progressPercent = percentFormatter.format(clampedProgress);
 
   if (entry.kind === "undo") {
     return (
       <article
-        key={`${area.id}-undo`}
         data-testid="offline-undo-card"
         className="offline-download__undo"
         aria-label={t("offline-downloads-undo-aria", {
@@ -103,7 +104,6 @@ export function OfflineDownloadCard({
 
   return (
     <article
-      key={area.id}
       data-testid="offline-download-card"
       className="offline-download__card"
       aria-labelledby={`${area.id}-title`}
@@ -143,7 +143,7 @@ export function OfflineDownloadCard({
           <div className="h-1.5 flex-1 rounded-full bg-base-300/60">
             <div
               className={`h-1.5 rounded-full ${area.status === "downloading" ? "bg-amber-400" : "bg-accent"}`}
-              style={{ width: `${Math.round(area.progress * 100)}%` }}
+              style={{ width: `${Math.round(clampedProgress * 100)}%` }}
             />
           </div>
           <MetaComponent as="span">{progressPercent}</MetaComponent>

--- a/src/app/features/offline/components/offline-download-card.tsx
+++ b/src/app/features/offline/components/offline-download-card.tsx
@@ -30,7 +30,7 @@ export type FormatAreaCopy = (area: OfflineMapArea) => {
 
 export type OfflineDownloadMetaComponent = (props: OfflineDownloadMetaProps) => JSX.Element;
 
-type OfflineDownloadCardProps = {
+export type OfflineDownloadCardProps = {
   readonly entry: DownloadEntry;
   readonly isManaging: boolean;
   readonly statusLabels: DownloadStatusLabels;

--- a/src/app/features/offline/components/offline-download-card.tsx
+++ b/src/app/features/offline/components/offline-download-card.tsx
@@ -66,8 +66,10 @@ export function OfflineDownloadCard({
 }: OfflineDownloadCardProps): JSX.Element {
   const area = entry.area;
   const { localization, sizeLabel, updatedLabel } = formatAreaCopy(area);
-  // Clamp progress to valid percentage bounds (0-100%)
-  const clampedProgress = Math.max(0, Math.min(1, area.progress));
+  // Clamp progress to valid percentage bounds (0-100%), defaulting to 0 for non-finite values
+  const clampedProgress = Number.isFinite(area.progress)
+    ? Math.max(0, Math.min(1, area.progress))
+    : 0;
   const progressPercent = percentFormatter.format(clampedProgress);
 
   if (entry.kind === "undo") {

--- a/src/app/features/offline/components/offline-download-card.tsx
+++ b/src/app/features/offline/components/offline-download-card.tsx
@@ -1,10 +1,11 @@
 /** @file Download and undo cards for offline map areas. */
 
 import type { TFunction } from "i18next";
-import type { JSX, ReactNode } from "react";
+import type { JSX } from "react";
 
 import { Icon } from "../../../components/icon";
 import type { OfflineMapArea } from "../../../data/stage-four";
+import type { OfflineDownloadMetaComponent, OfflineDownloadMetaProps } from "./offline-meta";
 
 export type DownloadEntry =
   | { kind: "download"; area: OfflineMapArea }
@@ -16,19 +17,13 @@ export type DownloadStatusLabels = {
   statusDownloadingLabel: string;
 };
 
-export type OfflineDownloadMetaProps = {
-  readonly as?: "p" | "span" | "div";
-  readonly className?: string;
-  readonly children: ReactNode;
-};
+export type { OfflineDownloadMetaProps };
 
 export type FormatAreaCopy = (area: OfflineMapArea) => {
   readonly localization: { name: string; description?: string };
   readonly sizeLabel: string;
   readonly updatedLabel: string;
 };
-
-export type OfflineDownloadMetaComponent = (props: OfflineDownloadMetaProps) => JSX.Element;
 
 export type OfflineDownloadCardProps = {
   readonly entry: DownloadEntry;

--- a/src/app/features/offline/components/offline-download-card.tsx
+++ b/src/app/features/offline/components/offline-download-card.tsx
@@ -16,17 +16,19 @@ export type DownloadStatusLabels = {
   statusDownloadingLabel: string;
 };
 
+export type OfflineDownloadMetaProps = {
+  readonly as?: "p" | "span" | "div";
+  readonly className?: string;
+  readonly children: ReactNode;
+};
+
 type FormatAreaCopy = (area: OfflineMapArea) => {
   readonly localization: { name: string; description?: string };
   readonly sizeLabel: string;
   readonly updatedLabel: string;
 };
 
-type OfflineDownloadMetaComponent = (props: {
-  readonly as?: "p" | "span" | "div";
-  readonly className?: string;
-  readonly children: ReactNode;
-}) => JSX.Element;
+type OfflineDownloadMetaComponent = (props: OfflineDownloadMetaProps) => JSX.Element;
 
 type OfflineDownloadCardProps = {
   readonly entry: DownloadEntry;

--- a/src/app/features/offline/components/offline-download-dialog.tsx
+++ b/src/app/features/offline/components/offline-download-dialog.tsx
@@ -1,0 +1,48 @@
+/** @file Dialog portal for selecting new offline downloads. */
+
+import * as Dialog from "@radix-ui/react-dialog";
+import type { JSX } from "react";
+
+import { Button } from "../../../components/button";
+
+export type OfflineDownloadDialogCopy = {
+  readonly title: string;
+  readonly description: string;
+  readonly searchPlaceholder: string;
+  readonly cancelLabel: string;
+  readonly previewLabel: string;
+};
+
+type OfflineDownloadDialogProps = {
+  readonly dialogCopy: OfflineDownloadDialogCopy | null;
+};
+
+export function OfflineDownloadDialog({ dialogCopy }: OfflineDownloadDialogProps): JSX.Element {
+  return (
+    <Dialog.Portal>
+      <Dialog.Overlay className="fixed inset-0 bg-black/60" />
+      <Dialog.Content className="dialog-surface">
+        <Dialog.Title className="text-lg font-semibold text-base-content">
+          {dialogCopy?.title ?? "Download new area"}
+        </Dialog.Title>
+        <Dialog.Description className="text-sm text-base-content/70">
+          {dialogCopy?.description ??
+            "Sync maps for offline access. Search for a city or drop a pin to select a custom region."}
+        </Dialog.Description>
+        <input
+          type="search"
+          placeholder={dialogCopy?.searchPlaceholder ?? "Search cities or regions"}
+          className="offline-search__input"
+        />
+        <div className="flex justify-end gap-2">
+          <Dialog.Close asChild>
+            <Button size="sm" variant="ghost">
+              {dialogCopy?.cancelLabel ?? "Cancel"}
+            </Button>
+          </Dialog.Close>
+          <Button size="sm">{dialogCopy?.previewLabel ?? "Preview download"}</Button>
+        </div>
+      </Dialog.Content>
+    </Dialog.Portal>
+  );
+}

--- a/src/app/features/offline/components/offline-download-dialog.tsx
+++ b/src/app/features/offline/components/offline-download-dialog.tsx
@@ -32,6 +32,7 @@ export function OfflineDownloadDialog({ dialogCopy }: OfflineDownloadDialogProps
         <input
           type="search"
           placeholder={dialogCopy?.searchPlaceholder ?? "Search cities or regions"}
+          aria-label={dialogCopy?.searchPlaceholder ?? "Search cities or regions"}
           className="offline-search__input"
         />
         <div className="flex justify-end gap-2">

--- a/src/app/features/offline/components/offline-download-dialog.tsx
+++ b/src/app/features/offline/components/offline-download-dialog.tsx
@@ -41,7 +41,10 @@ export function OfflineDownloadDialog({ dialogCopy }: OfflineDownloadDialogProps
               {dialogCopy?.cancelLabel ?? "Cancel"}
             </Button>
           </Dialog.Close>
-          <Button size="sm">{dialogCopy?.previewLabel ?? "Preview download"}</Button>
+          {/* TODO: implement preview handler */}
+          <Button size="sm" disabled>
+            {dialogCopy?.previewLabel ?? "Preview download"}
+          </Button>
         </div>
       </Dialog.Content>
     </Dialog.Portal>

--- a/src/app/features/offline/components/offline-downloads-section.tsx
+++ b/src/app/features/offline/components/offline-downloads-section.tsx
@@ -1,0 +1,106 @@
+/** @file Downloads list section for offline screen. */
+
+import type { TFunction } from "i18next";
+import type { JSX } from "react";
+
+import { Button } from "../../../components/button";
+import { formatStorageLabel } from "../../../config/offline-metrics";
+import type { OfflineMapArea } from "../../../data/stage-four";
+import { pickLocalization } from "../../../domain/entities/localization";
+import { formatRelativeTime } from "../../../lib/relative-time";
+import type {
+  DownloadEntry,
+  DownloadStatusLabels,
+  OfflineDownloadMetaProps,
+} from "./offline-download-card";
+import { OfflineDownloadCard } from "./offline-download-card";
+
+type OfflineDownloadsSectionProps = {
+  readonly downloads: DownloadEntry[];
+  readonly isManaging: boolean;
+  readonly statusLabels: DownloadStatusLabels;
+  readonly percentFormatter: Intl.NumberFormat;
+  readonly copy: {
+    readonly downloadsHeading: string;
+    readonly downloadsDescription: string;
+    readonly manageLabel: string;
+    readonly doneLabel: string;
+    readonly undoDescription: string;
+    readonly undoButtonLabel: string;
+  };
+  readonly undoDescriptionDefault: string;
+  readonly MetaComponent: (props: OfflineDownloadMetaProps) => JSX.Element;
+  readonly renderStatusBadge: (
+    status: OfflineMapArea["status"],
+    labels: DownloadStatusLabels,
+  ) => JSX.Element | null;
+  readonly t: TFunction;
+  readonly i18nLanguage: string;
+  readonly onDelete: (id: string) => void;
+  readonly onUndo: (id: string) => void;
+  readonly toggleManaging: () => void;
+};
+
+export function OfflineDownloadsSection({
+  downloads,
+  isManaging,
+  statusLabels,
+  percentFormatter,
+  copy,
+  undoDescriptionDefault,
+  MetaComponent,
+  renderStatusBadge,
+  t,
+  i18nLanguage,
+  onDelete,
+  onUndo,
+  toggleManaging,
+}: OfflineDownloadsSectionProps): JSX.Element {
+  const formatAreaCopy = (area: OfflineMapArea) => {
+    const localization = pickLocalization(area.localizations, i18nLanguage);
+    const sizeLabel = formatStorageLabel(area.sizeBytes);
+    const relativeUpdated = formatRelativeTime(area.lastUpdatedAt, i18nLanguage);
+    const updatedLabel = t("offline-downloads-updated", {
+      updated: relativeUpdated,
+      defaultValue: `Updated ${relativeUpdated}`,
+    });
+    return { localization, sizeLabel, updatedLabel };
+  };
+
+  return (
+    <section className="space-y-4" aria-labelledby="downloaded-areas-heading">
+      <header className="flex items-center justify-between">
+        <div>
+          <h2 id="downloaded-areas-heading" className="text-base font-semibold text-base-content">
+            {copy.downloadsHeading}
+          </h2>
+          <MetaComponent>{copy.downloadsDescription}</MetaComponent>
+        </div>
+        <Button size="sm" variant="ghost" aria-pressed={isManaging} onClick={toggleManaging}>
+          {isManaging ? copy.doneLabel : copy.manageLabel}
+        </Button>
+      </header>
+
+      <div className="space-y-3">
+        {downloads.map((entry) => (
+          <OfflineDownloadCard
+            key={entry.kind === "undo" ? `${entry.area.id}-undo` : entry.area.id}
+            entry={entry}
+            isManaging={isManaging}
+            statusLabels={statusLabels}
+            formatAreaCopy={formatAreaCopy}
+            percentFormatter={percentFormatter}
+            undoDescription={copy.undoDescription}
+            undoDescriptionDefault={undoDescriptionDefault}
+            undoButtonLabel={copy.undoButtonLabel}
+            MetaComponent={MetaComponent}
+            renderStatusBadge={renderStatusBadge}
+            onDelete={onDelete}
+            onUndo={onUndo}
+            t={t}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/features/offline/components/offline-downloads-section.tsx
+++ b/src/app/features/offline/components/offline-downloads-section.tsx
@@ -8,6 +8,7 @@ import { formatStorageLabel } from "../../../config/offline-metrics";
 import type { OfflineMapArea } from "../../../data/stage-four";
 import { pickLocalization } from "../../../domain/entities/localization";
 import { formatRelativeTime } from "../../../lib/relative-time";
+import { getNow } from "../../../lib/time";
 import type {
   DownloadEntry,
   DownloadStatusLabels,
@@ -60,7 +61,7 @@ export function OfflineDownloadsSection({
     (area: OfflineMapArea) => {
       const localization = pickLocalization(area.localizations, i18nLanguage);
       const sizeLabel = formatStorageLabel(area.sizeBytes);
-      const relativeUpdated = formatRelativeTime(area.lastUpdatedAt, i18nLanguage);
+      const relativeUpdated = formatRelativeTime(area.lastUpdatedAt, i18nLanguage, getNow());
       const updatedLabel = t("offline-downloads-updated", {
         updated: relativeUpdated,
         defaultValue: `Updated ${relativeUpdated}`,

--- a/src/app/features/offline/components/offline-downloads-section.tsx
+++ b/src/app/features/offline/components/offline-downloads-section.tsx
@@ -1,7 +1,7 @@
 /** @file Downloads list section for offline screen. */
 
 import type { TFunction } from "i18next";
-import type { JSX } from "react";
+import { type JSX, useCallback } from "react";
 
 import { Button } from "../../../components/button";
 import { formatStorageLabel } from "../../../config/offline-metrics";
@@ -56,16 +56,19 @@ export function OfflineDownloadsSection({
   onUndo,
   toggleManaging,
 }: OfflineDownloadsSectionProps): JSX.Element {
-  const formatAreaCopy = (area: OfflineMapArea) => {
-    const localization = pickLocalization(area.localizations, i18nLanguage);
-    const sizeLabel = formatStorageLabel(area.sizeBytes);
-    const relativeUpdated = formatRelativeTime(area.lastUpdatedAt, i18nLanguage);
-    const updatedLabel = t("offline-downloads-updated", {
-      updated: relativeUpdated,
-      defaultValue: `Updated ${relativeUpdated}`,
-    });
-    return { localization, sizeLabel, updatedLabel };
-  };
+  const formatAreaCopy = useCallback(
+    (area: OfflineMapArea) => {
+      const localization = pickLocalization(area.localizations, i18nLanguage);
+      const sizeLabel = formatStorageLabel(area.sizeBytes);
+      const relativeUpdated = formatRelativeTime(area.lastUpdatedAt, i18nLanguage);
+      const updatedLabel = t("offline-downloads-updated", {
+        updated: relativeUpdated,
+        defaultValue: `Updated ${relativeUpdated}`,
+      });
+      return { localization, sizeLabel, updatedLabel };
+    },
+    [i18nLanguage, t],
+  );
 
   return (
     <section className="space-y-4" aria-labelledby="downloaded-areas-heading">

--- a/src/app/features/offline/components/offline-downloads-section.tsx
+++ b/src/app/features/offline/components/offline-downloads-section.tsx
@@ -16,7 +16,7 @@ import type {
 } from "./offline-download-card";
 import { OfflineDownloadCard } from "./offline-download-card";
 
-type OfflineDownloadsSectionProps = {
+export type OfflineDownloadsSectionProps = {
   readonly downloads: DownloadEntry[];
   readonly isManaging: boolean;
   readonly statusLabels: DownloadStatusLabels;

--- a/src/app/features/offline/components/offline-header.tsx
+++ b/src/app/features/offline/components/offline-header.tsx
@@ -1,0 +1,42 @@
+/** @file Header component for offline screen. */
+
+import * as Dialog from "@radix-ui/react-dialog";
+import type { JSX } from "react";
+
+import { Icon } from "../../../components/icon";
+import { AppHeader } from "../../../layout/app-header";
+
+type OfflineHeaderProps = {
+  readonly headerTitle: string;
+  readonly headerSubtitle: string;
+  readonly backLabel: string;
+  readonly addAreaLabel: string;
+  readonly onBack: () => void;
+};
+
+export function OfflineHeader({
+  headerTitle,
+  headerSubtitle,
+  backLabel,
+  addAreaLabel,
+  onBack,
+}: OfflineHeaderProps): JSX.Element {
+  return (
+    <AppHeader
+      title={headerTitle}
+      subtitle={headerSubtitle}
+      leading={
+        <button type="button" aria-label={backLabel} className="header-nav-button" onClick={onBack}>
+          <Icon token="{icon.navigation.back}" aria-hidden className="h-5 w-5" />
+        </button>
+      }
+      trailing={
+        <Dialog.Trigger asChild>
+          <button type="button" aria-label={addAreaLabel} className="header-icon-button">
+            <Icon token="{icon.action.add}" aria-hidden className="h-5 w-5" />
+          </button>
+        </Dialog.Trigger>
+      }
+    />
+  );
+}

--- a/src/app/features/offline/components/offline-meta.ts
+++ b/src/app/features/offline/components/offline-meta.ts
@@ -1,0 +1,17 @@
+/** @file Shared types for offline meta components. */
+
+import type { JSX, ReactNode } from "react";
+
+/**
+ * Props for the meta text component used across offline UI.
+ */
+export type OfflineDownloadMetaProps = {
+  readonly as?: "p" | "span" | "div";
+  readonly className?: string;
+  readonly children: ReactNode;
+};
+
+/**
+ * Component type for rendering meta text in offline downloads.
+ */
+export type OfflineDownloadMetaComponent = (props: OfflineDownloadMetaProps) => JSX.Element;

--- a/src/app/features/offline/components/offline-screen-content.tsx
+++ b/src/app/features/offline/components/offline-screen-content.tsx
@@ -1,0 +1,170 @@
+/** @file Presentational layout for the offline screen. */
+
+import * as Dialog from "@radix-ui/react-dialog";
+import type { TFunction } from "i18next";
+import type { Dispatch, JSX, SetStateAction } from "react";
+
+import { AppBottomNavigation } from "../../../components/app-bottom-navigation";
+import { bottomNavigation } from "../../../data/customize";
+import {
+  autoManagementOptions,
+  type OfflineMapArea,
+  type OfflineSuggestion,
+} from "../../../data/stage-four";
+import { OfflineAutoManagement } from "./offline-auto-management";
+import type {
+  DownloadEntry,
+  DownloadStatusLabels,
+  OfflineDownloadMetaProps,
+} from "./offline-download-card";
+import { OfflineDownloadDialog } from "./offline-download-dialog";
+import { OfflineDownloadsSection } from "./offline-downloads-section";
+import { OfflineHeader } from "./offline-header";
+import { OfflineStorageOverview } from "./offline-storage-overview";
+import { OfflineSuggestionsSection } from "./offline-suggestions-section";
+
+type OfflineScreenContentProps = {
+  readonly navigationCopy: {
+    readonly headerTitle: string;
+    readonly headerSubtitle: string;
+    readonly backLabel: string;
+    readonly addAreaLabel: string;
+    readonly bottomNavAriaLabel: string;
+  };
+  readonly storageCopy: ReturnType<
+    typeof import("../hooks/use-offline-storage-copy").useOfflineStorageCopy
+  >;
+  readonly suggestions: OfflineSuggestion[];
+  readonly suggestionsCopy: ReturnType<
+    typeof import("../hooks/use-offline-suggestions-copy").useOfflineSuggestionsCopy
+  >;
+  readonly setSuggestions: Dispatch<SetStateAction<OfflineSuggestion[]>>;
+  readonly downloads: DownloadEntry[];
+  readonly isManaging: boolean;
+  readonly statusLabels: DownloadStatusLabels;
+  readonly percentFormatter: Intl.NumberFormat;
+  readonly downloadsCopy: ReturnType<
+    typeof import("../hooks/use-offline-downloads-copy").useOfflineDownloadsCopy
+  >["copy"];
+  readonly undoDescriptionDefault: string;
+  readonly MetaComponent: (props: OfflineDownloadMetaProps) => JSX.Element;
+  readonly renderStatusBadge: (
+    status: OfflineMapArea["status"],
+    labels: DownloadStatusLabels,
+  ) => JSX.Element | null;
+  readonly t: TFunction;
+  readonly i18nLanguage: string;
+  readonly onDelete: (id: string) => void;
+  readonly onUndo: (id: string) => void;
+  readonly toggleManaging: () => void;
+  readonly autoSettings: Record<string, boolean>;
+  readonly onToggleAuto: (id: string, next: boolean) => void;
+  readonly integerFormatter: Intl.NumberFormat;
+  readonly dialogCopy: ReturnType<
+    typeof import("../hooks/use-offline-dialog-copy").useOfflineDialogCopy
+  >;
+  readonly dialogOpen: boolean;
+  readonly setDialogOpen: (next: boolean) => void;
+  readonly onBack: () => void;
+};
+
+export function OfflineScreenContent({
+  navigationCopy,
+  storageCopy,
+  suggestions,
+  suggestionsCopy,
+  setSuggestions,
+  downloads,
+  isManaging,
+  statusLabels,
+  percentFormatter,
+  downloadsCopy,
+  undoDescriptionDefault,
+  MetaComponent,
+  renderStatusBadge,
+  t,
+  i18nLanguage,
+  onDelete,
+  onUndo,
+  toggleManaging,
+  autoSettings,
+  onToggleAuto,
+  integerFormatter,
+  dialogCopy,
+  dialogOpen,
+  setDialogOpen,
+  onBack,
+}: OfflineScreenContentProps): JSX.Element {
+  return (
+    <Dialog.Root open={dialogOpen} onOpenChange={setDialogOpen}>
+      <div className="screen-stack">
+        <OfflineHeader
+          headerTitle={navigationCopy.headerTitle}
+          headerSubtitle={navigationCopy.headerSubtitle}
+          backLabel={navigationCopy.backLabel}
+          addAreaLabel={navigationCopy.addAreaLabel}
+          onBack={onBack}
+        />
+
+        <main className="screen-scroll space-y-6 pt-6">
+          <OfflineStorageOverview
+            storageHeading={storageCopy.heading}
+            storageSubtitle={storageCopy.subtitle}
+            storageUsedLabel={storageCopy.usedLabel}
+            storageUsedDescription={storageCopy.usedDescription}
+            storageMapsLabel={storageCopy.mapsLabel}
+            storageAvailableLabel={storageCopy.availableLabel}
+            MetaComponent={MetaComponent}
+          />
+
+          {suggestionsCopy ? (
+            <OfflineSuggestionsSection
+              suggestions={suggestions}
+              heading={suggestionsCopy.heading}
+              dismissLabel={suggestionsCopy.dismissLabel}
+              i18nLanguage={i18nLanguage}
+              onDismiss={(id) => setSuggestions((prev) => prev.filter((item) => item.id !== id))}
+            />
+          ) : null}
+
+          <OfflineDownloadsSection
+            downloads={downloads}
+            isManaging={isManaging}
+            statusLabels={statusLabels}
+            percentFormatter={percentFormatter}
+            copy={downloadsCopy}
+            undoDescriptionDefault={undoDescriptionDefault}
+            MetaComponent={MetaComponent}
+            renderStatusBadge={renderStatusBadge}
+            t={t}
+            i18nLanguage={i18nLanguage}
+            onDelete={onDelete}
+            onUndo={onUndo}
+            toggleManaging={toggleManaging}
+          />
+
+          <OfflineAutoManagement
+            autoHeading={downloadsCopy.autoHeading}
+            autoManagementOptions={autoManagementOptions}
+            autoSettings={autoSettings}
+            onToggle={onToggleAuto}
+            integerFormatter={integerFormatter}
+            i18nLanguage={i18nLanguage}
+            t={t}
+          />
+        </main>
+
+        <AppBottomNavigation
+          aria-label={navigationCopy.bottomNavAriaLabel}
+          items={bottomNavigation.map((item) => ({
+            ...item,
+            label: t(`nav-${item.id}-label`, { defaultValue: item.label }),
+            isActive: item.id === "profile",
+          }))}
+        />
+      </div>
+
+      <OfflineDownloadDialog dialogCopy={dialogCopy} />
+    </Dialog.Root>
+  );
+}

--- a/src/app/features/offline/components/offline-screen-content.tsx
+++ b/src/app/features/offline/components/offline-screen-content.tsx
@@ -27,7 +27,7 @@ import { OfflineHeader } from "./offline-header";
 import { OfflineStorageOverview } from "./offline-storage-overview";
 import { OfflineSuggestionsSection } from "./offline-suggestions-section";
 
-type OfflineScreenContentProps = {
+export type OfflineScreenContentProps = {
   readonly navigationCopy: {
     readonly headerTitle: string;
     readonly headerSubtitle: string;

--- a/src/app/features/offline/components/offline-screen-content.tsx
+++ b/src/app/features/offline/components/offline-screen-content.tsx
@@ -121,6 +121,7 @@ export function OfflineScreenContent({
               heading={suggestionsCopy.heading}
               dismissLabel={suggestionsCopy.dismissLabel}
               i18nLanguage={i18nLanguage}
+              onAction={() => setDialogOpen(true)}
               onDismiss={(id) => setSuggestions((prev) => prev.filter((item) => item.id !== id))}
             />
           ) : null}

--- a/src/app/features/offline/components/offline-screen-content.tsx
+++ b/src/app/features/offline/components/offline-screen-content.tsx
@@ -11,6 +11,10 @@ import {
   type OfflineMapArea,
   type OfflineSuggestion,
 } from "../../../data/stage-four";
+import type { OfflineDialogCopy } from "../hooks/use-offline-dialog-copy";
+import type { OfflineDownloadsCopy } from "../hooks/use-offline-downloads-copy";
+import type { OfflineStorageCopy } from "../hooks/use-offline-storage-copy";
+import type { OfflineSuggestionsCopy } from "../hooks/use-offline-suggestions-copy";
 import { OfflineAutoManagement } from "./offline-auto-management";
 import type {
   DownloadEntry,
@@ -31,21 +35,15 @@ type OfflineScreenContentProps = {
     readonly addAreaLabel: string;
     readonly bottomNavAriaLabel: string;
   };
-  readonly storageCopy: ReturnType<
-    typeof import("../hooks/use-offline-storage-copy").useOfflineStorageCopy
-  >;
+  readonly storageCopy: OfflineStorageCopy;
   readonly suggestions: OfflineSuggestion[];
-  readonly suggestionsCopy: ReturnType<
-    typeof import("../hooks/use-offline-suggestions-copy").useOfflineSuggestionsCopy
-  >;
+  readonly suggestionsCopy: OfflineSuggestionsCopy;
   readonly setSuggestions: Dispatch<SetStateAction<OfflineSuggestion[]>>;
   readonly downloads: DownloadEntry[];
   readonly isManaging: boolean;
   readonly statusLabels: DownloadStatusLabels;
   readonly percentFormatter: Intl.NumberFormat;
-  readonly downloadsCopy: ReturnType<
-    typeof import("../hooks/use-offline-downloads-copy").useOfflineDownloadsCopy
-  >["copy"];
+  readonly downloadsCopy: OfflineDownloadsCopy;
   readonly undoDescriptionDefault: string;
   readonly MetaComponent: (props: OfflineDownloadMetaProps) => JSX.Element;
   readonly renderStatusBadge: (
@@ -60,9 +58,7 @@ type OfflineScreenContentProps = {
   readonly autoSettings: Record<string, boolean>;
   readonly onToggleAuto: (id: string, next: boolean) => void;
   readonly integerFormatter: Intl.NumberFormat;
-  readonly dialogCopy: ReturnType<
-    typeof import("../hooks/use-offline-dialog-copy").useOfflineDialogCopy
-  >;
+  readonly dialogCopy: OfflineDialogCopy;
   readonly dialogOpen: boolean;
   readonly setDialogOpen: (next: boolean) => void;
   readonly onBack: () => void;

--- a/src/app/features/offline/components/offline-screen-content.tsx
+++ b/src/app/features/offline/components/offline-screen-content.tsx
@@ -62,6 +62,7 @@ type OfflineScreenContentProps = {
   readonly dialogOpen: boolean;
   readonly setDialogOpen: (next: boolean) => void;
   readonly onBack: () => void;
+  readonly activeNavId: string;
 };
 
 export function OfflineScreenContent({
@@ -90,6 +91,7 @@ export function OfflineScreenContent({
   dialogOpen,
   setDialogOpen,
   onBack,
+  activeNavId,
 }: OfflineScreenContentProps): JSX.Element {
   return (
     <Dialog.Root open={dialogOpen} onOpenChange={setDialogOpen}>
@@ -155,7 +157,7 @@ export function OfflineScreenContent({
           items={bottomNavigation.map((item) => ({
             ...item,
             label: t(`nav-${item.id}-label`, { defaultValue: item.label }),
-            isActive: item.id === "profile",
+            isActive: item.id === activeNavId,
           }))}
         />
       </div>

--- a/src/app/features/offline/components/offline-storage-overview.tsx
+++ b/src/app/features/offline/components/offline-storage-overview.tsx
@@ -4,7 +4,7 @@ import type { JSX, ReactNode } from "react";
 
 import { Icon } from "../../../components/icon";
 
-type OfflineDownloadMetaComponent = (props: {
+export type OfflineDownloadMetaComponent = (props: {
   readonly as?: "p" | "span" | "div";
   readonly className?: string;
   readonly children: ReactNode;

--- a/src/app/features/offline/components/offline-storage-overview.tsx
+++ b/src/app/features/offline/components/offline-storage-overview.tsx
@@ -47,6 +47,7 @@ export function OfflineStorageOverview({
             </MetaComponent>
           </div>
           <div className="h-2 w-full rounded-full bg-base-300/60">
+            {/* Placeholder: 35% progress until real storage API is wired */}
             <div className="h-2 w-[35%] rounded-full bg-accent" />
           </div>
         </div>

--- a/src/app/features/offline/components/offline-storage-overview.tsx
+++ b/src/app/features/offline/components/offline-storage-overview.tsx
@@ -10,7 +10,7 @@ type OfflineDownloadMetaComponent = (props: {
   readonly children: ReactNode;
 }) => JSX.Element;
 
-type OfflineStorageOverviewProps = {
+export type OfflineStorageOverviewProps = {
   readonly storageHeading: string;
   readonly storageSubtitle: string;
   readonly storageUsedLabel: string;

--- a/src/app/features/offline/components/offline-storage-overview.tsx
+++ b/src/app/features/offline/components/offline-storage-overview.tsx
@@ -1,14 +1,9 @@
 /** @file Storage overview panel for offline downloads. */
 
-import type { JSX, ReactNode } from "react";
+import type { JSX } from "react";
 
 import { Icon } from "../../../components/icon";
-
-export type OfflineDownloadMetaComponent = (props: {
-  readonly as?: "p" | "span" | "div";
-  readonly className?: string;
-  readonly children: ReactNode;
-}) => JSX.Element;
+import type { OfflineDownloadMetaComponent } from "./offline-meta";
 
 export type OfflineStorageOverviewProps = {
   readonly storageHeading: string;

--- a/src/app/features/offline/components/offline-storage-overview.tsx
+++ b/src/app/features/offline/components/offline-storage-overview.tsx
@@ -1,0 +1,66 @@
+/** @file Storage overview panel for offline downloads. */
+
+import type { JSX, ReactNode } from "react";
+
+import { Icon } from "../../../components/icon";
+
+type OfflineDownloadMetaComponent = (props: {
+  readonly as?: "p" | "span" | "div";
+  readonly className?: string;
+  readonly children: ReactNode;
+}) => JSX.Element;
+
+type OfflineStorageOverviewProps = {
+  readonly storageHeading: string;
+  readonly storageSubtitle: string;
+  readonly storageUsedLabel: string;
+  readonly storageUsedDescription: string;
+  readonly storageMapsLabel: string;
+  readonly storageAvailableLabel: string;
+  readonly MetaComponent: OfflineDownloadMetaComponent;
+};
+
+export function OfflineStorageOverview({
+  storageHeading,
+  storageSubtitle,
+  storageUsedLabel,
+  storageUsedDescription,
+  storageMapsLabel,
+  storageAvailableLabel,
+  MetaComponent,
+}: OfflineStorageOverviewProps): JSX.Element {
+  return (
+    <section className="offline-overview__panel">
+      <div className="mb-4 flex items-center gap-3">
+        <Icon token="{icon.action.download}" className="text-accent" aria-hidden />
+        <div>
+          <p className="text-sm font-medium text-base-content">{storageHeading}</p>
+          <MetaComponent>{storageSubtitle}</MetaComponent>
+        </div>
+      </div>
+      <div className="space-y-3">
+        <div>
+          <div className="split-row">
+            <MetaComponent as="span">{storageUsedLabel}</MetaComponent>
+            <MetaComponent as="span" className="font-semibold text-base-content">
+              {storageUsedDescription}
+            </MetaComponent>
+          </div>
+          <div className="h-2 w-full rounded-full bg-base-300/60">
+            <div className="h-2 w-[35%] rounded-full bg-accent" />
+          </div>
+        </div>
+        <div className="flex items-center gap-3 text-xs text-base-content/60">
+          <span className="flex items-center gap-1">
+            <span className="block h-2 w-2 rounded-full bg-accent" />
+            {storageMapsLabel}
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="block h-2 w-2 rounded-full bg-base-300/80" />
+            {storageAvailableLabel}
+          </span>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/features/offline/components/offline-suggestion-card.tsx
+++ b/src/app/features/offline/components/offline-suggestion-card.tsx
@@ -11,6 +11,7 @@
  * />
  */
 
+import clsx from "clsx";
 import type { JSX } from "react";
 
 import { Button } from "../../../components/button";
@@ -38,13 +39,16 @@ export function OfflineSuggestionCard({
 
   return (
     <article
-      className={`rounded-2xl border border-base-300/60 bg-gradient-to-r p-4 shadow-lg ${suggestion.accentClass}`}
+      className={clsx(
+        "rounded-2xl border border-base-300/60 bg-gradient-to-r p-4 shadow-lg",
+        suggestion.accentClass,
+      )}
       aria-label={suggestionCopy.name}
     >
       <div className="flex items-start gap-3 text-base-100">
         <Icon
           token={suggestion.iconToken}
-          className={`text-xl ${suggestion.iconClassName ?? ""}`.trim()}
+          className={clsx("text-xl", suggestion.iconClassName)}
           aria-hidden
         />
         <div className="flex-1">

--- a/src/app/features/offline/components/offline-suggestion-card.tsx
+++ b/src/app/features/offline/components/offline-suggestion-card.tsx
@@ -25,7 +25,7 @@ export function OfflineSuggestionCard({
 
   return (
     <article
-      className={`rounded-2xl border border-base-300/60 bg-gradient-to-r ${suggestion.accentClass} p-4 shadow-lg`}
+      className={`rounded-2xl border border-base-300/60 bg-gradient-to-r p-4 shadow-lg ${suggestion.accentClass}`}
     >
       <div className="flex items-start gap-3 text-base-100">
         <Icon

--- a/src/app/features/offline/components/offline-suggestion-card.tsx
+++ b/src/app/features/offline/components/offline-suggestion-card.tsx
@@ -1,0 +1,54 @@
+/** @file Card component for recommended offline map downloads. */
+
+import type { JSX } from "react";
+
+import { Button } from "../../../components/button";
+import { Icon } from "../../../components/icon";
+import type { OfflineSuggestion } from "../../../data/stage-four";
+import { pickLocalization } from "../../../domain/entities/localization";
+
+type OfflineSuggestionCardProps = {
+  readonly suggestion: OfflineSuggestion;
+  readonly dismissLabel: string;
+  readonly i18nLanguage: string;
+  readonly onDismiss: () => void;
+};
+
+export function OfflineSuggestionCard({
+  suggestion,
+  dismissLabel,
+  i18nLanguage,
+  onDismiss,
+}: OfflineSuggestionCardProps): JSX.Element {
+  const suggestionCopy = pickLocalization(suggestion.localizations, i18nLanguage);
+  const ctaCopy = pickLocalization(suggestion.ctaLocalizations, i18nLanguage);
+
+  return (
+    <article
+      className={`rounded-2xl border border-base-300/60 bg-gradient-to-r ${suggestion.accentClass} p-4 shadow-lg`}
+    >
+      <div className="flex items-start gap-3 text-base-100">
+        <Icon
+          token={suggestion.iconToken}
+          className={`text-xl ${suggestion.iconClassName ?? ""}`.trim()}
+          aria-hidden
+        />
+        <div className="flex-1">
+          <h3 className="text-base font-semibold text-base-100">{suggestionCopy.name}</h3>
+          <p className="mt-1 text-sm text-base-100/80">{suggestionCopy.description}</p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <Button size="sm">{ctaCopy.name}</Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="border-white/40 text-base-100 hover:bg-white/10"
+              onClick={onDismiss}
+            >
+              {dismissLabel}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/app/features/offline/components/offline-suggestion-card.tsx
+++ b/src/app/features/offline/components/offline-suggestion-card.tsx
@@ -1,4 +1,15 @@
-/** @file Card component for recommended offline map downloads. */
+/**
+ * @file Card component for recommended offline map downloads.
+ *
+ * @example
+ * <OfflineSuggestionCard
+ *   suggestion={offlineSuggestions[0]}
+ *   dismissLabel="Dismiss"
+ *   i18nLanguage="en-GB"
+ *   onAction={() => console.log("download started")}
+ *   onDismiss={() => console.log("dismissed")}
+ * />
+ */
 
 import type { JSX } from "react";
 
@@ -11,6 +22,7 @@ type OfflineSuggestionCardProps = {
   readonly suggestion: OfflineSuggestion;
   readonly dismissLabel: string;
   readonly i18nLanguage: string;
+  readonly onAction: () => void;
   readonly onDismiss: () => void;
 };
 
@@ -18,6 +30,7 @@ export function OfflineSuggestionCard({
   suggestion,
   dismissLabel,
   i18nLanguage,
+  onAction,
   onDismiss,
 }: OfflineSuggestionCardProps): JSX.Element {
   const suggestionCopy = pickLocalization(suggestion.localizations, i18nLanguage);
@@ -26,6 +39,7 @@ export function OfflineSuggestionCard({
   return (
     <article
       className={`rounded-2xl border border-base-300/60 bg-gradient-to-r p-4 shadow-lg ${suggestion.accentClass}`}
+      aria-label={suggestionCopy.name}
     >
       <div className="flex items-start gap-3 text-base-100">
         <Icon
@@ -37,7 +51,9 @@ export function OfflineSuggestionCard({
           <h3 className="text-base font-semibold text-base-100">{suggestionCopy.name}</h3>
           <p className="mt-1 text-sm text-base-100/80">{suggestionCopy.description}</p>
           <div className="mt-3 flex flex-wrap gap-2">
-            <Button size="sm">{ctaCopy.name}</Button>
+            <Button size="sm" onClick={onAction}>
+              {ctaCopy.name}
+            </Button>
             <Button
               size="sm"
               variant="ghost"

--- a/src/app/features/offline/components/offline-suggestions-section.tsx
+++ b/src/app/features/offline/components/offline-suggestions-section.tsx
@@ -7,7 +7,7 @@
  * OfflineScreen complexity.
  */
 
-import type { JSX } from "react";
+import { type JSX, useId } from "react";
 
 import type { OfflineSuggestion } from "../../../data/stage-four";
 import { OfflineSuggestionCard } from "./offline-suggestion-card";
@@ -29,13 +29,15 @@ export function OfflineSuggestionsSection({
   onAction,
   onDismiss,
 }: OfflineSuggestionsSectionProps): JSX.Element | null {
+  const headingId = useId();
+
   if (suggestions.length === 0) {
     return null;
   }
 
   return (
-    <section className="space-y-3" aria-labelledby="offline-suggestions-heading">
-      <h2 id="offline-suggestions-heading" className="text-base font-semibold text-base-content">
+    <section className="space-y-3" aria-labelledby={headingId}>
+      <h2 id={headingId} className="text-base font-semibold text-base-content">
         {heading}
       </h2>
       {suggestions.map((suggestion) => (

--- a/src/app/features/offline/components/offline-suggestions-section.tsx
+++ b/src/app/features/offline/components/offline-suggestions-section.tsx
@@ -5,7 +5,7 @@ import type { JSX } from "react";
 import type { OfflineSuggestion } from "../../../data/stage-four";
 import { OfflineSuggestionCard } from "./offline-suggestion-card";
 
-type OfflineSuggestionsSectionProps = {
+export type OfflineSuggestionsSectionProps = {
   readonly suggestions: OfflineSuggestion[];
   readonly heading: string;
   readonly dismissLabel: string;

--- a/src/app/features/offline/components/offline-suggestions-section.tsx
+++ b/src/app/features/offline/components/offline-suggestions-section.tsx
@@ -6,7 +6,7 @@ import type { OfflineSuggestion } from "../../../data/stage-four";
 import { OfflineSuggestionCard } from "./offline-suggestion-card";
 
 export type OfflineSuggestionsSectionProps = {
-  readonly suggestions: OfflineSuggestion[];
+  readonly suggestions: readonly OfflineSuggestion[];
   readonly heading: string;
   readonly dismissLabel: string;
   readonly i18nLanguage: string;

--- a/src/app/features/offline/components/offline-suggestions-section.tsx
+++ b/src/app/features/offline/components/offline-suggestions-section.tsx
@@ -1,4 +1,11 @@
-/** @file Suggestions section wrapper for offline screen. */
+/**
+ * @file Suggestions section for the offline screen.
+ *
+ * Renders a titled list of offline suggestions as cards, or null when empty.
+ * Localization is delegated to OfflineSuggestionCard; this component wires
+ * user actions (onAction/onDismiss) by suggestion ID. Extracted to reduce
+ * OfflineScreen complexity.
+ */
 
 import type { JSX } from "react";
 
@@ -27,8 +34,10 @@ export function OfflineSuggestionsSection({
   }
 
   return (
-    <section className="space-y-3">
-      <h2 className="text-base font-semibold text-base-content">{heading}</h2>
+    <section className="space-y-3" aria-labelledby="offline-suggestions-heading">
+      <h2 id="offline-suggestions-heading" className="text-base font-semibold text-base-content">
+        {heading}
+      </h2>
       {suggestions.map((suggestion) => (
         <OfflineSuggestionCard
           key={suggestion.id}

--- a/src/app/features/offline/components/offline-suggestions-section.tsx
+++ b/src/app/features/offline/components/offline-suggestions-section.tsx
@@ -1,0 +1,41 @@
+/** @file Suggestions section wrapper for offline screen. */
+
+import type { JSX } from "react";
+
+import type { OfflineSuggestion } from "../../../data/stage-four";
+import { OfflineSuggestionCard } from "./offline-suggestion-card";
+
+type OfflineSuggestionsSectionProps = {
+  readonly suggestions: OfflineSuggestion[];
+  readonly heading: string;
+  readonly dismissLabel: string;
+  readonly i18nLanguage: string;
+  readonly onDismiss: (id: string) => void;
+};
+
+export function OfflineSuggestionsSection({
+  suggestions,
+  heading,
+  dismissLabel,
+  i18nLanguage,
+  onDismiss,
+}: OfflineSuggestionsSectionProps): JSX.Element | null {
+  if (suggestions.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="space-y-3">
+      <h2 className="text-base font-semibold text-base-content">{heading}</h2>
+      {suggestions.map((suggestion) => (
+        <OfflineSuggestionCard
+          key={suggestion.id}
+          suggestion={suggestion}
+          dismissLabel={dismissLabel}
+          i18nLanguage={i18nLanguage}
+          onDismiss={() => onDismiss(suggestion.id)}
+        />
+      ))}
+    </section>
+  );
+}

--- a/src/app/features/offline/components/offline-suggestions-section.tsx
+++ b/src/app/features/offline/components/offline-suggestions-section.tsx
@@ -10,6 +10,7 @@ type OfflineSuggestionsSectionProps = {
   readonly heading: string;
   readonly dismissLabel: string;
   readonly i18nLanguage: string;
+  readonly onAction: (id: string) => void;
   readonly onDismiss: (id: string) => void;
 };
 
@@ -18,6 +19,7 @@ export function OfflineSuggestionsSection({
   heading,
   dismissLabel,
   i18nLanguage,
+  onAction,
   onDismiss,
 }: OfflineSuggestionsSectionProps): JSX.Element | null {
   if (suggestions.length === 0) {
@@ -33,6 +35,7 @@ export function OfflineSuggestionsSection({
           suggestion={suggestion}
           dismissLabel={dismissLabel}
           i18nLanguage={i18nLanguage}
+          onAction={() => onAction(suggestion.id)}
           onDismiss={() => onDismiss(suggestion.id)}
         />
       ))}

--- a/src/app/features/offline/hooks/use-offline-dialog-copy.ts
+++ b/src/app/features/offline/hooks/use-offline-dialog-copy.ts
@@ -3,7 +3,15 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
-export const useOfflineDialogCopy = (dialogOpen: boolean) => {
+export type OfflineDialogCopy = {
+  readonly title: string;
+  readonly description: string;
+  readonly searchPlaceholder: string;
+  readonly cancelLabel: string;
+  readonly previewLabel: string;
+} | null;
+
+export const useOfflineDialogCopy = (dialogOpen: boolean): OfflineDialogCopy => {
   const { t } = useTranslation();
 
   return useMemo(() => {

--- a/src/app/features/offline/hooks/use-offline-dialog-copy.ts
+++ b/src/app/features/offline/hooks/use-offline-dialog-copy.ts
@@ -1,0 +1,29 @@
+/** @file Hook exposing dialog copy for the offline download modal. */
+
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+export const useOfflineDialogCopy = (dialogOpen: boolean) => {
+  const { t } = useTranslation();
+
+  return useMemo(() => {
+    if (!dialogOpen) {
+      return null;
+    }
+
+    return {
+      title: t("offline-dialog-title", { defaultValue: "Download new area" }),
+      description: t("offline-dialog-description", {
+        defaultValue:
+          "Sync maps for offline access. Search for a city or drop a pin to select a custom region.",
+      }),
+      searchPlaceholder: t("offline-dialog-search-placeholder", {
+        defaultValue: "Search cities or regions",
+      }),
+      cancelLabel: t("offline-dialog-cancel", { defaultValue: "Cancel" }),
+      previewLabel: t("offline-dialog-preview", {
+        defaultValue: "Preview download",
+      }),
+    } as const;
+  }, [dialogOpen, t]);
+};

--- a/src/app/features/offline/hooks/use-offline-downloads-copy.ts
+++ b/src/app/features/offline/hooks/use-offline-downloads-copy.ts
@@ -1,0 +1,44 @@
+/** @file Hook exposing downloads copy and constants for the offline screen. */
+
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+const undoDescriptionDefault = "Tap undo to restore this map.";
+
+export const useOfflineDownloadsCopy = () => {
+  const { t } = useTranslation();
+
+  const copy = useMemo(
+    () => ({
+      downloadsHeading: t("offline-downloads-heading", {
+        defaultValue: "Downloaded areas",
+      }),
+      downloadsDescription: t("offline-downloads-description", {
+        defaultValue: "Manage maps for offline navigation",
+      }),
+      manageLabel: t("offline-downloads-manage", { defaultValue: "Manage" }),
+      doneLabel: t("offline-downloads-done", { defaultValue: "Done" }),
+      statusCompleteLabel: t("offline-downloads-status-complete", {
+        defaultValue: "Complete",
+      }),
+      statusUpdatingLabel: t("offline-downloads-status-updating", {
+        defaultValue: "Update available",
+      }),
+      statusDownloadingLabel: t("offline-downloads-status-downloading", {
+        defaultValue: "Downloading",
+      }),
+      undoDescription: t("offline-downloads-undo-description", {
+        defaultValue: undoDescriptionDefault,
+      }),
+      undoButtonLabel: t("offline-downloads-undo-button", {
+        defaultValue: "Undo",
+      }),
+      autoHeading: t("offline-auto-heading", {
+        defaultValue: "Auto-Management",
+      }),
+    }),
+    [t],
+  );
+
+  return { copy, undoDescriptionDefault } as const;
+};

--- a/src/app/features/offline/hooks/use-offline-downloads-copy.ts
+++ b/src/app/features/offline/hooks/use-offline-downloads-copy.ts
@@ -3,9 +3,25 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
+export type OfflineDownloadsCopy = {
+  readonly downloadsHeading: string;
+  readonly downloadsDescription: string;
+  readonly manageLabel: string;
+  readonly doneLabel: string;
+  readonly statusCompleteLabel: string;
+  readonly statusUpdatingLabel: string;
+  readonly statusDownloadingLabel: string;
+  readonly undoDescription: string;
+  readonly undoButtonLabel: string;
+  readonly autoHeading: string;
+};
+
 const undoDescriptionDefault = "Tap undo to restore this map.";
 
-export const useOfflineDownloadsCopy = () => {
+export const useOfflineDownloadsCopy = (): {
+  readonly copy: OfflineDownloadsCopy;
+  readonly undoDescriptionDefault: string;
+} => {
   const { t } = useTranslation();
 
   const copy = useMemo(

--- a/src/app/features/offline/hooks/use-offline-downloads-state.ts
+++ b/src/app/features/offline/hooks/use-offline-downloads-state.ts
@@ -5,7 +5,15 @@ import { useCallback, useState } from "react";
 import type { OfflineMapArea } from "../../../data/stage-four";
 import type { DownloadEntry } from "../components/offline-download-card";
 
-export const useOfflineDownloadsState = (initialAreas: OfflineMapArea[]) => {
+export type OfflineDownloadsState = {
+  readonly downloads: DownloadEntry[];
+  readonly isManaging: boolean;
+  readonly handleDeleteDownload: (downloadId: string) => void;
+  readonly handleUndoDownload: (downloadId: string) => void;
+  readonly toggleManaging: () => void;
+};
+
+export const useOfflineDownloadsState = (initialAreas: OfflineMapArea[]): OfflineDownloadsState => {
   const [downloads, setDownloads] = useState<DownloadEntry[]>(() =>
     initialAreas.map((area) => ({ kind: "download", area })),
   );
@@ -50,5 +58,5 @@ export const useOfflineDownloadsState = (initialAreas: OfflineMapArea[]) => {
     handleDeleteDownload,
     handleUndoDownload,
     toggleManaging,
-  } as const;
+  };
 };

--- a/src/app/features/offline/hooks/use-offline-downloads-state.ts
+++ b/src/app/features/offline/hooks/use-offline-downloads-state.ts
@@ -1,0 +1,47 @@
+/** @file Hook managing offline downloads list and managing state. */
+
+import { useState } from "react";
+
+import type { OfflineMapArea } from "../../../data/stage-four";
+import type { DownloadEntry } from "../components/offline-download-card";
+
+export const useOfflineDownloadsState = (initialAreas: OfflineMapArea[]) => {
+  const [downloads, setDownloads] = useState<DownloadEntry[]>(() =>
+    initialAreas.map((area) => ({ kind: "download", area })),
+  );
+  const [isManaging, setIsManaging] = useState(false);
+
+  const handleDeleteDownload = (downloadId: string) => {
+    if (!isManaging) return;
+    setDownloads((current) =>
+      current.map((entry) =>
+        entry.area.id === downloadId ? { kind: "undo", area: entry.area } : entry,
+      ),
+    );
+  };
+
+  const handleUndoDownload = (downloadId: string) => {
+    setDownloads((current) =>
+      current.map((entry) =>
+        entry.area.id === downloadId ? { kind: "download", area: entry.area } : entry,
+      ),
+    );
+  };
+
+  const toggleManaging = () => {
+    setIsManaging((prev) => {
+      if (prev) {
+        setDownloads((current) => current.filter((entry) => entry.kind === "download"));
+      }
+      return !prev;
+    });
+  };
+
+  return {
+    downloads,
+    isManaging,
+    handleDeleteDownload,
+    handleUndoDownload,
+    toggleManaging,
+  } as const;
+};

--- a/src/app/features/offline/hooks/use-offline-downloads-state.ts
+++ b/src/app/features/offline/hooks/use-offline-downloads-state.ts
@@ -1,6 +1,6 @@
 /** @file Hook managing offline downloads list and managing state. */
 
-import { useState } from "react";
+import { useCallback, useState } from "react";
 
 import type { OfflineMapArea } from "../../../data/stage-four";
 import type { DownloadEntry } from "../components/offline-download-card";
@@ -11,31 +11,38 @@ export const useOfflineDownloadsState = (initialAreas: OfflineMapArea[]) => {
   );
   const [isManaging, setIsManaging] = useState(false);
 
-  const handleDeleteDownload = (downloadId: string) => {
-    if (!isManaging) return;
-    setDownloads((current) =>
-      current.map((entry) =>
-        entry.area.id === downloadId ? { kind: "undo", area: entry.area } : entry,
-      ),
-    );
-  };
+  const handleDeleteDownload = useCallback(
+    (downloadId: string) => {
+      if (!isManaging) return;
+      setDownloads((current) =>
+        current.map((entry) =>
+          entry.area.id === downloadId ? { kind: "undo", area: entry.area } : entry,
+        ),
+      );
+    },
+    [isManaging],
+  );
 
-  const handleUndoDownload = (downloadId: string) => {
-    setDownloads((current) =>
-      current.map((entry) =>
-        entry.area.id === downloadId ? { kind: "download", area: entry.area } : entry,
-      ),
-    );
-  };
+  const handleUndoDownload = useCallback(
+    (downloadId: string) => {
+      if (!isManaging) return;
+      setDownloads((current) =>
+        current.map((entry) =>
+          entry.area.id === downloadId ? { kind: "download", area: entry.area } : entry,
+        ),
+      );
+    },
+    [isManaging],
+  );
 
-  const toggleManaging = () => {
+  const toggleManaging = useCallback(() => {
     setIsManaging((prev) => {
       if (prev) {
         setDownloads((current) => current.filter((entry) => entry.kind === "download"));
       }
       return !prev;
     });
-  };
+  }, []);
 
   return {
     downloads,

--- a/src/app/features/offline/hooks/use-offline-localizations.ts
+++ b/src/app/features/offline/hooks/use-offline-localizations.ts
@@ -1,0 +1,182 @@
+/** @file Collates localised copy for the offline management screen. */
+
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+export type OfflineLocalisations = {
+  readonly navigationCopy: {
+    readonly bottomNavAriaLabel: string;
+    readonly headerTitle: string;
+    readonly headerSubtitle: string;
+    readonly backLabel: string;
+    readonly addAreaLabel: string;
+  };
+  readonly storageCopy: {
+    readonly heading: string;
+    readonly subtitle: string;
+    readonly usedLabel: string;
+    readonly usedDescription: string;
+    readonly mapsLabel: string;
+    readonly availableLabel: string;
+  };
+  readonly downloadsCopy: {
+    readonly downloadsHeading: string;
+    readonly downloadsDescription: string;
+    readonly manageLabel: string;
+    readonly doneLabel: string;
+    readonly statusCompleteLabel: string;
+    readonly statusUpdatingLabel: string;
+    readonly statusDownloadingLabel: string;
+    readonly undoDescription: string;
+    readonly undoButtonLabel: string;
+    readonly autoHeading: string;
+  };
+  readonly suggestionsCopy: {
+    readonly heading: string;
+    readonly dismissLabel: string;
+  } | null;
+  readonly dialogCopy: {
+    readonly title: string;
+    readonly description: string;
+    readonly searchPlaceholder: string;
+    readonly cancelLabel: string;
+    readonly previewLabel: string;
+  } | null;
+  readonly undoDescriptionDefault: string;
+};
+
+type OfflineLocalisationOptions = {
+  readonly storageUsedFormatted: string;
+  readonly storageTotalFormatted: string;
+  readonly storageAutoDeleteDays: number;
+  readonly suggestionsLength: number;
+  readonly dialogOpen: boolean;
+};
+
+export const useOfflineLocalisations = ({
+  storageUsedFormatted,
+  storageTotalFormatted,
+  storageAutoDeleteDays,
+  suggestionsLength,
+  dialogOpen,
+}: OfflineLocalisationOptions): OfflineLocalisations => {
+  const { t } = useTranslation();
+  const undoDescriptionDefault = "Tap undo to restore this map.";
+
+  const navigationCopy = useMemo(
+    () => ({
+      bottomNavAriaLabel: t("nav-primary-aria-label", {
+        defaultValue: "Primary navigation",
+      }),
+      headerTitle: t("offline-header-title", { defaultValue: "Offline Maps" }),
+      headerSubtitle: t("offline-header-subtitle", {
+        defaultValue: "Manage downloads and smart updates",
+      }),
+      backLabel: t("offline-header-back-label", {
+        defaultValue: "Back to map",
+      }),
+      addAreaLabel: t("offline-header-add-area-label", {
+        defaultValue: "Add offline area",
+      }),
+    }),
+    [t],
+  );
+
+  const storageCopy = useMemo(
+    () => ({
+      heading: t("offline-storage-heading", {
+        defaultValue: "Storage overview",
+      }),
+      subtitle: t("offline-storage-subtitle", {
+        days: storageAutoDeleteDays,
+        defaultValue: `Auto-delete unused maps after ${storageAutoDeleteDays} days`,
+      }),
+      usedLabel: t("offline-storage-used-label", { defaultValue: "Used" }),
+      usedDescription: t("offline-storage-used-description", {
+        used: storageUsedFormatted,
+        total: storageTotalFormatted,
+        defaultValue: `${storageUsedFormatted} of ${storageTotalFormatted}`,
+      }),
+      mapsLabel: t("offline-storage-legend-maps", { defaultValue: "Maps" }),
+      availableLabel: t("offline-storage-legend-available", {
+        defaultValue: "Available space",
+      }),
+    }),
+    [storageAutoDeleteDays, storageTotalFormatted, storageUsedFormatted, t],
+  );
+
+  const downloadsCopy = useMemo(
+    () => ({
+      downloadsHeading: t("offline-downloads-heading", {
+        defaultValue: "Downloaded areas",
+      }),
+      downloadsDescription: t("offline-downloads-description", {
+        defaultValue: "Manage maps for offline navigation",
+      }),
+      manageLabel: t("offline-downloads-manage", { defaultValue: "Manage" }),
+      doneLabel: t("offline-downloads-done", { defaultValue: "Done" }),
+      statusCompleteLabel: t("offline-downloads-status-complete", {
+        defaultValue: "Complete",
+      }),
+      statusUpdatingLabel: t("offline-downloads-status-updating", {
+        defaultValue: "Update available",
+      }),
+      statusDownloadingLabel: t("offline-downloads-status-downloading", {
+        defaultValue: "Downloading",
+      }),
+      undoDescription: t("offline-downloads-undo-description", {
+        defaultValue: undoDescriptionDefault,
+      }),
+      undoButtonLabel: t("offline-downloads-undo-button", {
+        defaultValue: "Undo",
+      }),
+      autoHeading: t("offline-auto-heading", {
+        defaultValue: "Auto-Management",
+      }),
+    }),
+    [t],
+  );
+
+  const suggestionsCopy = useMemo(() => {
+    if (suggestionsLength === 0) {
+      return null;
+    }
+    return {
+      heading: t("offline-suggestions-heading", {
+        defaultValue: "Smart travel hints",
+      }),
+      dismissLabel: t("offline-suggestion-dismiss", {
+        defaultValue: "Dismiss",
+      }),
+    } as const;
+  }, [suggestionsLength, t]);
+
+  const dialogCopy = useMemo(() => {
+    if (!dialogOpen) {
+      return null;
+    }
+    return {
+      title: t("offline-dialog-title", { defaultValue: "Download new area" }),
+      description: t("offline-dialog-description", {
+        defaultValue:
+          "Sync maps for offline access. Search for a city or drop a pin to select a custom region.",
+      }),
+      searchPlaceholder: t("offline-dialog-search-placeholder", {
+        defaultValue: "Search cities or regions",
+      }),
+      cancelLabel: t("offline-dialog-cancel", { defaultValue: "Cancel" }),
+      previewLabel: t("offline-dialog-preview", {
+        defaultValue: "Preview download",
+      }),
+    } as const;
+  }, [dialogOpen, t]);
+
+  return {
+    navigationCopy,
+    storageCopy,
+    downloadsCopy,
+    suggestionsCopy,
+    dialogCopy,
+    undoDescriptionDefault,
+  };
+};

--- a/src/app/features/offline/hooks/use-offline-localizations.ts
+++ b/src/app/features/offline/hooks/use-offline-localizations.ts
@@ -15,7 +15,7 @@ export type OfflineLocalisations = {
   readonly undoDescriptionDefault: string;
 };
 
-type OfflineLocalisationOptions = {
+export type OfflineLocalisationOptions = {
   readonly storageUsedFormatted: string;
   readonly storageTotalFormatted: string;
   readonly storageAutoDeleteDays: number;

--- a/src/app/features/offline/hooks/use-offline-localizations.ts
+++ b/src/app/features/offline/hooks/use-offline-localizations.ts
@@ -1,47 +1,17 @@
-/** @file Collates localised copy for the offline management screen. */
+/** @file Aggregates localisation hooks for the offline screen. */
 
-import { useMemo } from "react";
-import { useTranslation } from "react-i18next";
+import { useOfflineDialogCopy } from "./use-offline-dialog-copy";
+import { useOfflineDownloadsCopy } from "./use-offline-downloads-copy";
+import { useOfflineNavigationCopy } from "./use-offline-navigation-copy";
+import { useOfflineStorageCopy } from "./use-offline-storage-copy";
+import { useOfflineSuggestionsCopy } from "./use-offline-suggestions-copy";
 
 export type OfflineLocalisations = {
-  readonly navigationCopy: {
-    readonly bottomNavAriaLabel: string;
-    readonly headerTitle: string;
-    readonly headerSubtitle: string;
-    readonly backLabel: string;
-    readonly addAreaLabel: string;
-  };
-  readonly storageCopy: {
-    readonly heading: string;
-    readonly subtitle: string;
-    readonly usedLabel: string;
-    readonly usedDescription: string;
-    readonly mapsLabel: string;
-    readonly availableLabel: string;
-  };
-  readonly downloadsCopy: {
-    readonly downloadsHeading: string;
-    readonly downloadsDescription: string;
-    readonly manageLabel: string;
-    readonly doneLabel: string;
-    readonly statusCompleteLabel: string;
-    readonly statusUpdatingLabel: string;
-    readonly statusDownloadingLabel: string;
-    readonly undoDescription: string;
-    readonly undoButtonLabel: string;
-    readonly autoHeading: string;
-  };
-  readonly suggestionsCopy: {
-    readonly heading: string;
-    readonly dismissLabel: string;
-  } | null;
-  readonly dialogCopy: {
-    readonly title: string;
-    readonly description: string;
-    readonly searchPlaceholder: string;
-    readonly cancelLabel: string;
-    readonly previewLabel: string;
-  } | null;
+  readonly navigationCopy: ReturnType<typeof useOfflineNavigationCopy>;
+  readonly storageCopy: ReturnType<typeof useOfflineStorageCopy>;
+  readonly downloadsCopy: ReturnType<typeof useOfflineDownloadsCopy>["copy"];
+  readonly suggestionsCopy: ReturnType<typeof useOfflineSuggestionsCopy>;
+  readonly dialogCopy: ReturnType<typeof useOfflineDialogCopy>;
   readonly undoDescriptionDefault: string;
 };
 
@@ -60,116 +30,15 @@ export const useOfflineLocalisations = ({
   suggestionsLength,
   dialogOpen,
 }: OfflineLocalisationOptions): OfflineLocalisations => {
-  const { t } = useTranslation();
-  const undoDescriptionDefault = "Tap undo to restore this map.";
-
-  const navigationCopy = useMemo(
-    () => ({
-      bottomNavAriaLabel: t("nav-primary-aria-label", {
-        defaultValue: "Primary navigation",
-      }),
-      headerTitle: t("offline-header-title", { defaultValue: "Offline Maps" }),
-      headerSubtitle: t("offline-header-subtitle", {
-        defaultValue: "Manage downloads and smart updates",
-      }),
-      backLabel: t("offline-header-back-label", {
-        defaultValue: "Back to map",
-      }),
-      addAreaLabel: t("offline-header-add-area-label", {
-        defaultValue: "Add offline area",
-      }),
-    }),
-    [t],
+  const navigationCopy = useOfflineNavigationCopy();
+  const storageCopy = useOfflineStorageCopy(
+    storageUsedFormatted,
+    storageTotalFormatted,
+    storageAutoDeleteDays,
   );
-
-  const storageCopy = useMemo(
-    () => ({
-      heading: t("offline-storage-heading", {
-        defaultValue: "Storage overview",
-      }),
-      subtitle: t("offline-storage-subtitle", {
-        days: storageAutoDeleteDays,
-        defaultValue: `Auto-delete unused maps after ${storageAutoDeleteDays} days`,
-      }),
-      usedLabel: t("offline-storage-used-label", { defaultValue: "Used" }),
-      usedDescription: t("offline-storage-used-description", {
-        used: storageUsedFormatted,
-        total: storageTotalFormatted,
-        defaultValue: `${storageUsedFormatted} of ${storageTotalFormatted}`,
-      }),
-      mapsLabel: t("offline-storage-legend-maps", { defaultValue: "Maps" }),
-      availableLabel: t("offline-storage-legend-available", {
-        defaultValue: "Available space",
-      }),
-    }),
-    [storageAutoDeleteDays, storageTotalFormatted, storageUsedFormatted, t],
-  );
-
-  const downloadsCopy = useMemo(
-    () => ({
-      downloadsHeading: t("offline-downloads-heading", {
-        defaultValue: "Downloaded areas",
-      }),
-      downloadsDescription: t("offline-downloads-description", {
-        defaultValue: "Manage maps for offline navigation",
-      }),
-      manageLabel: t("offline-downloads-manage", { defaultValue: "Manage" }),
-      doneLabel: t("offline-downloads-done", { defaultValue: "Done" }),
-      statusCompleteLabel: t("offline-downloads-status-complete", {
-        defaultValue: "Complete",
-      }),
-      statusUpdatingLabel: t("offline-downloads-status-updating", {
-        defaultValue: "Update available",
-      }),
-      statusDownloadingLabel: t("offline-downloads-status-downloading", {
-        defaultValue: "Downloading",
-      }),
-      undoDescription: t("offline-downloads-undo-description", {
-        defaultValue: undoDescriptionDefault,
-      }),
-      undoButtonLabel: t("offline-downloads-undo-button", {
-        defaultValue: "Undo",
-      }),
-      autoHeading: t("offline-auto-heading", {
-        defaultValue: "Auto-Management",
-      }),
-    }),
-    [t],
-  );
-
-  const suggestionsCopy = useMemo(() => {
-    if (suggestionsLength === 0) {
-      return null;
-    }
-    return {
-      heading: t("offline-suggestions-heading", {
-        defaultValue: "Smart travel hints",
-      }),
-      dismissLabel: t("offline-suggestion-dismiss", {
-        defaultValue: "Dismiss",
-      }),
-    } as const;
-  }, [suggestionsLength, t]);
-
-  const dialogCopy = useMemo(() => {
-    if (!dialogOpen) {
-      return null;
-    }
-    return {
-      title: t("offline-dialog-title", { defaultValue: "Download new area" }),
-      description: t("offline-dialog-description", {
-        defaultValue:
-          "Sync maps for offline access. Search for a city or drop a pin to select a custom region.",
-      }),
-      searchPlaceholder: t("offline-dialog-search-placeholder", {
-        defaultValue: "Search cities or regions",
-      }),
-      cancelLabel: t("offline-dialog-cancel", { defaultValue: "Cancel" }),
-      previewLabel: t("offline-dialog-preview", {
-        defaultValue: "Preview download",
-      }),
-    } as const;
-  }, [dialogOpen, t]);
+  const { copy: downloadsCopy, undoDescriptionDefault } = useOfflineDownloadsCopy();
+  const suggestionsCopy = useOfflineSuggestionsCopy(suggestionsLength);
+  const dialogCopy = useOfflineDialogCopy(dialogOpen);
 
   return {
     navigationCopy,

--- a/src/app/features/offline/hooks/use-offline-navigation-copy.ts
+++ b/src/app/features/offline/hooks/use-offline-navigation-copy.ts
@@ -3,7 +3,15 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
-export const useOfflineNavigationCopy = () => {
+type OfflineNavigationCopy = {
+  readonly bottomNavAriaLabel: string;
+  readonly headerTitle: string;
+  readonly headerSubtitle: string;
+  readonly backLabel: string;
+  readonly addAreaLabel: string;
+};
+
+export const useOfflineNavigationCopy = (): OfflineNavigationCopy => {
   const { t } = useTranslation();
 
   return useMemo(

--- a/src/app/features/offline/hooks/use-offline-navigation-copy.ts
+++ b/src/app/features/offline/hooks/use-offline-navigation-copy.ts
@@ -1,0 +1,27 @@
+/** @file Hook exposing navigation copy for the offline screen. */
+
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+export const useOfflineNavigationCopy = () => {
+  const { t } = useTranslation();
+
+  return useMemo(
+    () => ({
+      bottomNavAriaLabel: t("nav-primary-aria-label", {
+        defaultValue: "Primary navigation",
+      }),
+      headerTitle: t("offline-header-title", { defaultValue: "Offline Maps" }),
+      headerSubtitle: t("offline-header-subtitle", {
+        defaultValue: "Manage downloads and smart updates",
+      }),
+      backLabel: t("offline-header-back-label", {
+        defaultValue: "Back to map",
+      }),
+      addAreaLabel: t("offline-header-add-area-label", {
+        defaultValue: "Add offline area",
+      }),
+    }),
+    [t],
+  );
+};

--- a/src/app/features/offline/hooks/use-offline-storage-copy.ts
+++ b/src/app/features/offline/hooks/use-offline-storage-copy.ts
@@ -3,6 +3,15 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
+export type OfflineStorageCopy = {
+  readonly heading: string;
+  readonly subtitle: string;
+  readonly usedLabel: string;
+  readonly usedDescription: string;
+  readonly mapsLabel: string;
+  readonly availableLabel: string;
+};
+
 export const useOfflineStorageCopy = (
   storageUsedFormatted: string,
   storageTotalFormatted: string,

--- a/src/app/features/offline/hooks/use-offline-storage-copy.ts
+++ b/src/app/features/offline/hooks/use-offline-storage-copy.ts
@@ -1,0 +1,35 @@
+/** @file Hook exposing storage copy for the offline screen. */
+
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+export const useOfflineStorageCopy = (
+  storageUsedFormatted: string,
+  storageTotalFormatted: string,
+  storageAutoDeleteDays: number,
+) => {
+  const { t } = useTranslation();
+
+  return useMemo(
+    () => ({
+      heading: t("offline-storage-heading", {
+        defaultValue: "Storage overview",
+      }),
+      subtitle: t("offline-storage-subtitle", {
+        days: storageAutoDeleteDays,
+        defaultValue: `Auto-delete unused maps after ${storageAutoDeleteDays} days`,
+      }),
+      usedLabel: t("offline-storage-used-label", { defaultValue: "Used" }),
+      usedDescription: t("offline-storage-used-description", {
+        used: storageUsedFormatted,
+        total: storageTotalFormatted,
+        defaultValue: `${storageUsedFormatted} of ${storageTotalFormatted}`,
+      }),
+      mapsLabel: t("offline-storage-legend-maps", { defaultValue: "Maps" }),
+      availableLabel: t("offline-storage-legend-available", {
+        defaultValue: "Available space",
+      }),
+    }),
+    [storageAutoDeleteDays, storageTotalFormatted, storageUsedFormatted, t],
+  );
+};

--- a/src/app/features/offline/hooks/use-offline-suggestions-copy.ts
+++ b/src/app/features/offline/hooks/use-offline-suggestions-copy.ts
@@ -3,7 +3,12 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
-export const useOfflineSuggestionsCopy = (suggestionsLength: number) => {
+export type OfflineSuggestionsCopy = {
+  readonly heading: string;
+  readonly dismissLabel: string;
+} | null;
+
+export const useOfflineSuggestionsCopy = (suggestionsLength: number): OfflineSuggestionsCopy => {
   const { t } = useTranslation();
 
   return useMemo(() => {

--- a/src/app/features/offline/hooks/use-offline-suggestions-copy.ts
+++ b/src/app/features/offline/hooks/use-offline-suggestions-copy.ts
@@ -1,0 +1,23 @@
+/** @file Hook exposing suggestions copy for the offline screen. */
+
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+export const useOfflineSuggestionsCopy = (suggestionsLength: number) => {
+  const { t } = useTranslation();
+
+  return useMemo(() => {
+    if (suggestionsLength === 0) {
+      return null;
+    }
+
+    return {
+      heading: t("offline-suggestions-heading", {
+        defaultValue: "Smart travel hints",
+      }),
+      dismissLabel: t("offline-suggestion-dismiss", {
+        defaultValue: "Dismiss",
+      }),
+    } as const;
+  }, [suggestionsLength, t]);
+};

--- a/src/app/features/offline/offline-screen.tsx
+++ b/src/app/features/offline/offline-screen.tsx
@@ -20,13 +20,15 @@ import { useOfflineNavigationCopy } from "./hooks/use-offline-navigation-copy";
 import { useOfflineStorageCopy } from "./hooks/use-offline-storage-copy";
 import { useOfflineSuggestionsCopy } from "./hooks/use-offline-suggestions-copy";
 
-// biome-ignore format: compact status map to keep file concise.
-const statusBadgeByStatus = { complete: { className: "badge badge-success badge-sm", labelKey: "statusCompleteLabel" }, updating: { className: "badge badge-warning badge-sm", labelKey: "statusUpdatingLabel" }, downloading: { className: "badge badge-info badge-sm", labelKey: "statusDownloadingLabel" } } as const;
+const statusBadgeByStatus = {
+  complete: { className: "badge badge-success badge-sm", labelKey: "statusCompleteLabel" },
+  updating: { className: "badge badge-warning badge-sm", labelKey: "statusUpdatingLabel" },
+  downloading: { className: "badge badge-info badge-sm", labelKey: "statusDownloadingLabel" },
+} as const;
 
 const isDownloadStatus = (
   status: OfflineMapArea["status"],
-): status is keyof typeof statusBadgeByStatus =>
-  typeof status === "string" && status in statusBadgeByStatus;
+): status is keyof typeof statusBadgeByStatus => status in statusBadgeByStatus;
 
 const renderStatusBadge = (
   status: OfflineMapArea["status"],
@@ -79,11 +81,14 @@ export function OfflineScreen(): JSX.Element {
   const { copy: downloadsCopy, undoDescriptionDefault } = useOfflineDownloadsCopy();
   const suggestionsCopy = useOfflineSuggestionsCopy(suggestions.length);
   const dialogCopy = useOfflineDialogCopy(dialogOpen);
-  const statusLabels: OfflineDownloadCard.DownloadStatusLabels = {
-    statusCompleteLabel: downloadsCopy.statusCompleteLabel,
-    statusUpdatingLabel: downloadsCopy.statusUpdatingLabel,
-    statusDownloadingLabel: downloadsCopy.statusDownloadingLabel,
-  };
+  const statusLabels: OfflineDownloadCard.DownloadStatusLabels = useMemo(
+    () => ({
+      statusCompleteLabel: downloadsCopy.statusCompleteLabel,
+      statusUpdatingLabel: downloadsCopy.statusUpdatingLabel,
+      statusDownloadingLabel: downloadsCopy.statusDownloadingLabel,
+    }),
+    [downloadsCopy],
+  );
 
   const onToggleAuto = useCallback(
     (id: string, next: boolean) => setAutoSettings((current) => ({ ...current, [id]: next })),

--- a/src/app/features/offline/offline-screen.tsx
+++ b/src/app/features/offline/offline-screen.tsx
@@ -120,6 +120,7 @@ export function OfflineScreen(): JSX.Element {
         dialogOpen={dialogOpen}
         setDialogOpen={setDialogOpen}
         onBack={onBack}
+        activeNavId="profile"
       />
     </MobileShell>
   );

--- a/src/app/features/offline/offline-screen.tsx
+++ b/src/app/features/offline/offline-screen.tsx
@@ -1,316 +1,119 @@
 /** @file Offline download management screen with storage overview. */
-
-import * as Dialog from "@radix-ui/react-dialog";
 import { useNavigate } from "@tanstack/react-router";
-import { type JSX, type ReactNode, useMemo, useState } from "react";
+import { type JSX, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { AppBottomNavigation } from "../../components/app-bottom-navigation";
-import { Button } from "../../components/button";
-import { Icon } from "../../components/icon";
-import { formatStorageLabel, OFFLINE_STORAGE_PLACEHOLDERS } from "../../config/offline-metrics";
-import { bottomNavigation } from "../../data/customize";
+import { OFFLINE_STORAGE_PLACEHOLDERS } from "../../config/offline-metrics";
 import {
   autoManagementOptions,
   type OfflineMapArea,
   offlineMapAreas,
   offlineSuggestions,
 } from "../../data/stage-four";
-import { pickLocalization } from "../../domain/entities/localization";
-import { AppHeader } from "../../layout/app-header";
 import { MobileShell } from "../../layout/mobile-shell";
-import { formatRelativeTime } from "../../lib/relative-time";
-import { OfflineAutoManagement } from "./components/offline-auto-management";
-import {
-  type DownloadEntry,
-  type DownloadStatusLabels,
-  OfflineDownloadCard,
-} from "./components/offline-download-card";
-import { OfflineDownloadDialog } from "./components/offline-download-dialog";
-import { OfflineStorageOverview } from "./components/offline-storage-overview";
-import { OfflineSuggestionCard } from "./components/offline-suggestion-card";
-import { useOfflineLocalisations } from "./hooks/use-offline-localizations";
+import type * as OfflineDownloadCard from "./components/offline-download-card";
+import { OfflineScreenContent } from "./components/offline-screen-content";
+import { useOfflineDialogCopy } from "./hooks/use-offline-dialog-copy";
+import { useOfflineDownloadsCopy } from "./hooks/use-offline-downloads-copy";
+import { useOfflineDownloadsState } from "./hooks/use-offline-downloads-state";
+import { useOfflineNavigationCopy } from "./hooks/use-offline-navigation-copy";
+import { useOfflineStorageCopy } from "./hooks/use-offline-storage-copy";
+import { useOfflineSuggestionsCopy } from "./hooks/use-offline-suggestions-copy";
 
-type DownloadStatus = OfflineMapArea["status"];
+// biome-ignore format: compact status map to keep file concise.
+const statusBadgeByStatus = { complete: { className: "badge badge-success badge-sm", labelKey: "statusCompleteLabel" }, updating: { className: "badge badge-warning badge-sm", labelKey: "statusUpdatingLabel" }, downloading: { className: "badge badge-info badge-sm", labelKey: "statusDownloadingLabel" } } as const;
 
-type StatusBadgeConfig = { className: string; labelKey: keyof DownloadStatusLabels };
-
-const statusBadgeByStatus = {
-  complete: {
-    className: "badge badge-success badge-sm",
-    labelKey: "statusCompleteLabel",
-  },
-  updating: {
-    className: "badge badge-warning badge-sm",
-    labelKey: "statusUpdatingLabel",
-  },
-  downloading: {
-    className: "badge badge-info badge-sm",
-    labelKey: "statusDownloadingLabel",
-  },
-} satisfies Record<DownloadStatus, StatusBadgeConfig>;
-
-const isDownloadStatus = (status: OfflineMapArea["status"]): status is DownloadStatus => {
-  return typeof status === "string" && status in statusBadgeByStatus;
-};
+const isDownloadStatus = (
+  status: OfflineMapArea["status"],
+): status is keyof typeof statusBadgeByStatus =>
+  typeof status === "string" && status in statusBadgeByStatus;
 
 const renderStatusBadge = (
   status: OfflineMapArea["status"],
-  labels: DownloadStatusLabels,
+  labels: OfflineDownloadCard.DownloadStatusLabels,
 ): JSX.Element | null => {
-  if (!isDownloadStatus(status)) {
-    return null;
-  }
-
+  if (!isDownloadStatus(status)) return null;
   const config = statusBadgeByStatus[status];
   return <span className={config.className}>{labels[config.labelKey]}</span>;
 };
-
-export type OfflineDownloadMetaProps = {
-  readonly as?: "p" | "span" | "div";
-  readonly className?: string;
-  readonly children: ReactNode;
-};
-
-function OfflineDownloadMeta({
+const OfflineDownloadMeta = ({
   as = "p",
   className,
   children,
-}: OfflineDownloadMetaProps): JSX.Element {
+}: OfflineDownloadCard.OfflineDownloadMetaProps): JSX.Element => {
   const Tag = as;
   const composedClassName = className
     ? `offline-download__meta ${className}`
     : "offline-download__meta";
-
   return <Tag className={composedClassName}>{children}</Tag>;
-}
+};
 
 export function OfflineScreen(): JSX.Element {
   const navigate = useNavigate();
   const { t, i18n } = useTranslation();
   const [suggestions, setSuggestions] = useState(offlineSuggestions);
   const [dialogOpen, setDialogOpen] = useState(false);
-  const [downloads, setDownloads] = useState<DownloadEntry[]>(() =>
-    offlineMapAreas.map((area) => ({ kind: "download", area })),
-  );
-  const [isManaging, setIsManaging] = useState(false);
   const [autoSettings, setAutoSettings] = useState<Record<string, boolean>>(() =>
     autoManagementOptions.reduce<Record<string, boolean>>((acc, option) => {
       acc[option.id] = option.defaultEnabled;
       return acc;
     }, {}),
   );
-  const storageUsedFormatted = OFFLINE_STORAGE_PLACEHOLDERS.usedLabel;
-  const storageTotalFormatted = OFFLINE_STORAGE_PLACEHOLDERS.totalLabel;
-  const storageAutoDeleteDays = OFFLINE_STORAGE_PLACEHOLDERS.autoDeleteDays;
+  const { downloads, isManaging, handleDeleteDownload, handleUndoDownload, toggleManaging } =
+    useOfflineDownloadsState(offlineMapAreas);
 
   const percentFormatter = useMemo(
-    () =>
-      new Intl.NumberFormat(i18n.language, {
-        style: "percent",
-        maximumFractionDigits: 0,
-      }),
+    () => new Intl.NumberFormat(i18n.language, { style: "percent", maximumFractionDigits: 0 }),
     [i18n.language],
   );
-
   const integerFormatter = useMemo(
-    () =>
-      new Intl.NumberFormat(i18n.language, {
-        maximumFractionDigits: 0,
-      }),
+    () => new Intl.NumberFormat(i18n.language, { maximumFractionDigits: 0 }),
     [i18n.language],
   );
-
-  const localisation = useOfflineLocalisations({
-    storageUsedFormatted,
-    storageTotalFormatted,
-    storageAutoDeleteDays,
-    suggestionsLength: suggestions.length,
-    dialogOpen,
-  });
-
-  const {
-    navigationCopy,
-    storageCopy,
-    downloadsCopy,
-    suggestionsCopy,
-    dialogCopy,
-    undoDescriptionDefault,
-  } = localisation;
-
-  const formatAreaCopy = (area: OfflineMapArea) => {
-    const localization = pickLocalization(area.localizations, i18n.language);
-    const sizeLabel = formatStorageLabel(area.sizeBytes);
-    const relativeUpdated = formatRelativeTime(area.lastUpdatedAt, i18n.language);
-    const updatedLabel = t("offline-downloads-updated", {
-      updated: relativeUpdated,
-      defaultValue: `Updated ${relativeUpdated}`,
-    });
-    return { localization, sizeLabel, updatedLabel };
-  };
-
-  const statusLabels: DownloadStatusLabels = {
+  const navigationCopy = useOfflineNavigationCopy();
+  const storageCopy = useOfflineStorageCopy(
+    OFFLINE_STORAGE_PLACEHOLDERS.usedLabel,
+    OFFLINE_STORAGE_PLACEHOLDERS.totalLabel,
+    OFFLINE_STORAGE_PLACEHOLDERS.autoDeleteDays,
+  );
+  const { copy: downloadsCopy, undoDescriptionDefault } = useOfflineDownloadsCopy();
+  const suggestionsCopy = useOfflineSuggestionsCopy(suggestions.length);
+  const dialogCopy = useOfflineDialogCopy(dialogOpen);
+  const statusLabels: OfflineDownloadCard.DownloadStatusLabels = {
     statusCompleteLabel: downloadsCopy.statusCompleteLabel,
     statusUpdatingLabel: downloadsCopy.statusUpdatingLabel,
     statusDownloadingLabel: downloadsCopy.statusDownloadingLabel,
   };
 
-  const handleDeleteDownload = (downloadId: string) => {
-    if (!isManaging) return;
-    setDownloads((current) =>
-      current.map((entry) =>
-        entry.area.id === downloadId ? { kind: "undo", area: entry.area } : entry,
-      ),
-    );
-  };
-
-  const handleUndoDownload = (downloadId: string) => {
-    setDownloads((current) =>
-      current.map((entry) =>
-        entry.area.id === downloadId ? { kind: "download", area: entry.area } : entry,
-      ),
-    );
-  };
-
-  const handleToggleAutoSetting = (id: string, next: boolean) => {
-    setAutoSettings((current) => ({ ...current, [id]: next }));
-  };
-
   return (
     <MobileShell>
-      <Dialog.Root open={dialogOpen} onOpenChange={setDialogOpen}>
-        <div className="screen-stack">
-          <AppHeader
-            title={navigationCopy.headerTitle}
-            subtitle={navigationCopy.headerSubtitle}
-            leading={
-              <button
-                type="button"
-                aria-label={navigationCopy.backLabel}
-                className="header-nav-button"
-                onClick={() => navigate({ to: "/map/quick" })}
-              >
-                <Icon token="{icon.navigation.back}" aria-hidden className="h-5 w-5" />
-              </button>
-            }
-            trailing={
-              <Dialog.Trigger asChild>
-                <button
-                  type="button"
-                  aria-label={navigationCopy.addAreaLabel}
-                  className="header-icon-button"
-                >
-                  <Icon token="{icon.action.add}" aria-hidden className="h-5 w-5" />
-                </button>
-              </Dialog.Trigger>
-            }
-          />
-
-          <main className="screen-scroll space-y-6 pt-6">
-            <OfflineStorageOverview
-              storageHeading={storageCopy.heading}
-              storageSubtitle={storageCopy.subtitle}
-              storageUsedLabel={storageCopy.usedLabel}
-              storageUsedDescription={storageCopy.usedDescription}
-              storageMapsLabel={storageCopy.mapsLabel}
-              storageAvailableLabel={storageCopy.availableLabel}
-              MetaComponent={OfflineDownloadMeta}
-            />
-
-            {suggestionsCopy ? (
-              <section className="space-y-3">
-                <h2 className="text-base font-semibold text-base-content">
-                  {suggestionsCopy.heading}
-                </h2>
-                {suggestions.map((suggestion) => (
-                  <OfflineSuggestionCard
-                    key={suggestion.id}
-                    suggestion={suggestion}
-                    dismissLabel={suggestionsCopy.dismissLabel}
-                    i18nLanguage={i18n.language}
-                    onDismiss={() =>
-                      setSuggestions((prev) => prev.filter((item) => item.id !== suggestion.id))
-                    }
-                  />
-                ))}
-              </section>
-            ) : null}
-
-            <section className="space-y-4" aria-labelledby="downloaded-areas-heading">
-              <header className="flex items-center justify-between">
-                <div>
-                  <h2
-                    id="downloaded-areas-heading"
-                    className="text-base font-semibold text-base-content"
-                  >
-                    {downloadsCopy.downloadsHeading}
-                  </h2>
-                  <OfflineDownloadMeta>{downloadsCopy.downloadsDescription}</OfflineDownloadMeta>
-                </div>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  aria-pressed={isManaging}
-                  onClick={() =>
-                    setIsManaging((prev) => {
-                      if (prev) {
-                        setDownloads((current) =>
-                          current.filter((entry) => entry.kind === "download"),
-                        );
-                      }
-                      return !prev;
-                    })
-                  }
-                >
-                  {isManaging ? downloadsCopy.doneLabel : downloadsCopy.manageLabel}
-                </Button>
-              </header>
-
-              <div className="space-y-3">
-                {downloads.map((entry) => (
-                  <OfflineDownloadCard
-                    key={entry.kind === "undo" ? `${entry.area.id}-undo` : entry.area.id}
-                    entry={entry}
-                    isManaging={isManaging}
-                    statusLabels={statusLabels}
-                    formatAreaCopy={formatAreaCopy}
-                    percentFormatter={percentFormatter}
-                    undoDescription={downloadsCopy.undoDescription}
-                    undoDescriptionDefault={undoDescriptionDefault}
-                    undoButtonLabel={downloadsCopy.undoButtonLabel}
-                    MetaComponent={OfflineDownloadMeta}
-                    renderStatusBadge={renderStatusBadge}
-                    onDelete={handleDeleteDownload}
-                    onUndo={handleUndoDownload}
-                    t={t}
-                  />
-                ))}
-              </div>
-            </section>
-
-            <OfflineAutoManagement
-              autoHeading={downloadsCopy.autoHeading}
-              autoManagementOptions={autoManagementOptions}
-              autoSettings={autoSettings}
-              onToggle={handleToggleAutoSetting}
-              integerFormatter={integerFormatter}
-              i18nLanguage={i18n.language}
-              t={t}
-            />
-          </main>
-
-          <AppBottomNavigation
-            aria-label={navigationCopy.bottomNavAriaLabel}
-            items={bottomNavigation.map((item) => ({
-              ...item,
-              label: t(`nav-${item.id}-label`, { defaultValue: item.label }),
-              isActive: item.id === "profile",
-            }))}
-          />
-        </div>
-
-        <OfflineDownloadDialog dialogCopy={dialogCopy} />
-      </Dialog.Root>
+      <OfflineScreenContent
+        navigationCopy={navigationCopy}
+        storageCopy={storageCopy}
+        suggestions={suggestions}
+        suggestionsCopy={suggestionsCopy}
+        setSuggestions={setSuggestions}
+        downloads={downloads}
+        isManaging={isManaging}
+        statusLabels={statusLabels}
+        percentFormatter={percentFormatter}
+        downloadsCopy={downloadsCopy}
+        undoDescriptionDefault={undoDescriptionDefault}
+        MetaComponent={OfflineDownloadMeta}
+        renderStatusBadge={renderStatusBadge}
+        t={t}
+        i18nLanguage={i18n.language}
+        onDelete={handleDeleteDownload}
+        onUndo={handleUndoDownload}
+        toggleManaging={toggleManaging}
+        autoSettings={autoSettings}
+        onToggleAuto={(id, next) => setAutoSettings((current) => ({ ...current, [id]: next }))}
+        integerFormatter={integerFormatter}
+        dialogCopy={dialogCopy}
+        dialogOpen={dialogOpen}
+        setDialogOpen={setDialogOpen}
+        onBack={() => navigate({ to: "/map/quick" })}
+      />
     </MobileShell>
   );
 }

--- a/src/app/features/offline/offline-screen.tsx
+++ b/src/app/features/offline/offline-screen.tsx
@@ -1,6 +1,6 @@
 /** @file Offline download management screen with storage overview. */
 import { useNavigate } from "@tanstack/react-router";
-import { type JSX, useMemo, useState } from "react";
+import { type JSX, useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { OFFLINE_STORAGE_PLACEHOLDERS } from "../../config/offline-metrics";
@@ -85,6 +85,13 @@ export function OfflineScreen(): JSX.Element {
     statusDownloadingLabel: downloadsCopy.statusDownloadingLabel,
   };
 
+  const onToggleAuto = useCallback(
+    (id: string, next: boolean) => setAutoSettings((current) => ({ ...current, [id]: next })),
+    [],
+  );
+
+  const onBack = useCallback(() => navigate({ to: "/map/quick" }), [navigate]);
+
   return (
     <MobileShell>
       <OfflineScreenContent
@@ -107,12 +114,12 @@ export function OfflineScreen(): JSX.Element {
         onUndo={handleUndoDownload}
         toggleManaging={toggleManaging}
         autoSettings={autoSettings}
-        onToggleAuto={(id, next) => setAutoSettings((current) => ({ ...current, [id]: next }))}
+        onToggleAuto={onToggleAuto}
         integerFormatter={integerFormatter}
         dialogCopy={dialogCopy}
         dialogOpen={dialogOpen}
         setDialogOpen={setDialogOpen}
-        onBack={() => navigate({ to: "/map/quick" })}
+        onBack={onBack}
       />
     </MobileShell>
   );

--- a/src/app/features/offline/offline-screen.tsx
+++ b/src/app/features/offline/offline-screen.tsx
@@ -8,7 +8,6 @@ import { useTranslation } from "react-i18next";
 import { AppBottomNavigation } from "../../components/app-bottom-navigation";
 import { Button } from "../../components/button";
 import { Icon } from "../../components/icon";
-import { PreferenceToggleCard } from "../../components/preference-toggle-card";
 import { formatStorageLabel, OFFLINE_STORAGE_PLACEHOLDERS } from "../../config/offline-metrics";
 import { bottomNavigation } from "../../data/customize";
 import {
@@ -21,14 +20,18 @@ import { pickLocalization } from "../../domain/entities/localization";
 import { AppHeader } from "../../layout/app-header";
 import { MobileShell } from "../../layout/mobile-shell";
 import { formatRelativeTime } from "../../lib/relative-time";
+import { OfflineAutoManagement } from "./components/offline-auto-management";
+import {
+  type DownloadEntry,
+  type DownloadStatusLabels,
+  OfflineDownloadCard,
+} from "./components/offline-download-card";
+import { OfflineDownloadDialog } from "./components/offline-download-dialog";
+import { OfflineStorageOverview } from "./components/offline-storage-overview";
+import { OfflineSuggestionCard } from "./components/offline-suggestion-card";
+import { useOfflineLocalisations } from "./hooks/use-offline-localizations";
 
 type DownloadStatus = OfflineMapArea["status"];
-
-type DownloadStatusLabels = {
-  statusCompleteLabel: string;
-  statusUpdatingLabel: string;
-  statusDownloadingLabel: string;
-};
 
 type StatusBadgeConfig = { className: string; labelKey: keyof DownloadStatusLabels };
 
@@ -63,7 +66,7 @@ const renderStatusBadge = (
   return <span className={config.className}>{labels[config.labelKey]}</span>;
 };
 
-type OfflineDownloadMetaProps = {
+export type OfflineDownloadMetaProps = {
   readonly as?: "p" | "span" | "div";
   readonly className?: string;
   readonly children: ReactNode;
@@ -87,10 +90,6 @@ export function OfflineScreen(): JSX.Element {
   const { t, i18n } = useTranslation();
   const [suggestions, setSuggestions] = useState(offlineSuggestions);
   const [dialogOpen, setDialogOpen] = useState(false);
-  type DownloadEntry =
-    | { kind: "download"; area: OfflineMapArea }
-    | { kind: "undo"; area: OfflineMapArea };
-
   const [downloads, setDownloads] = useState<DownloadEntry[]>(() =>
     offlineMapAreas.map((area) => ({ kind: "download", area })),
   );
@@ -104,139 +103,6 @@ export function OfflineScreen(): JSX.Element {
   const storageUsedFormatted = OFFLINE_STORAGE_PLACEHOLDERS.usedLabel;
   const storageTotalFormatted = OFFLINE_STORAGE_PLACEHOLDERS.totalLabel;
   const storageAutoDeleteDays = OFFLINE_STORAGE_PLACEHOLDERS.autoDeleteDays;
-
-  const navigationCopy = useMemo(
-    () => ({
-      bottomNavAriaLabel: t("nav-primary-aria-label", {
-        defaultValue: "Primary navigation",
-      }),
-      headerTitle: t("offline-header-title", { defaultValue: "Offline Maps" }),
-      headerSubtitle: t("offline-header-subtitle", {
-        defaultValue: "Manage downloads and smart updates",
-      }),
-      backLabel: t("offline-header-back-label", {
-        defaultValue: "Back to map",
-      }),
-      addAreaLabel: t("offline-header-add-area-label", {
-        defaultValue: "Add offline area",
-      }),
-    }),
-    [t],
-  );
-
-  const storageCopy = useMemo(
-    () => ({
-      heading: t("offline-storage-heading", {
-        defaultValue: "Storage overview",
-      }),
-      subtitle: t("offline-storage-subtitle", {
-        days: storageAutoDeleteDays,
-        defaultValue: `Auto-delete unused maps after ${storageAutoDeleteDays} days`,
-      }),
-      usedLabel: t("offline-storage-used-label", { defaultValue: "Used" }),
-      usedDescription: t("offline-storage-used-description", {
-        used: storageUsedFormatted,
-        total: storageTotalFormatted,
-        defaultValue: `${storageUsedFormatted} of ${storageTotalFormatted}`,
-      }),
-      mapsLabel: t("offline-storage-legend-maps", { defaultValue: "Maps" }),
-      availableLabel: t("offline-storage-legend-available", {
-        defaultValue: "Available space",
-      }),
-    }),
-    [storageAutoDeleteDays, storageTotalFormatted, storageUsedFormatted, t],
-  );
-
-  const undoDescriptionDefault = "Tap undo to restore this map.";
-
-  const downloadsCopy = useMemo(
-    () => ({
-      downloadsHeading: t("offline-downloads-heading", {
-        defaultValue: "Downloaded areas",
-      }),
-      downloadsDescription: t("offline-downloads-description", {
-        defaultValue: "Manage maps for offline navigation",
-      }),
-      manageLabel: t("offline-downloads-manage", { defaultValue: "Manage" }),
-      doneLabel: t("offline-downloads-done", { defaultValue: "Done" }),
-      statusCompleteLabel: t("offline-downloads-status-complete", {
-        defaultValue: "Complete",
-      }),
-      statusUpdatingLabel: t("offline-downloads-status-updating", {
-        defaultValue: "Update available",
-      }),
-      statusDownloadingLabel: t("offline-downloads-status-downloading", {
-        defaultValue: "Downloading",
-      }),
-      undoDescription: t("offline-downloads-undo-description", {
-        defaultValue: undoDescriptionDefault,
-      }),
-      undoButtonLabel: t("offline-downloads-undo-button", {
-        defaultValue: "Undo",
-      }),
-      autoHeading: t("offline-auto-heading", {
-        defaultValue: "Auto-Management",
-      }),
-    }),
-    [t],
-  );
-
-  const suggestionsCopy = useMemo(() => {
-    if (suggestions.length === 0) {
-      return null;
-    }
-    return {
-      heading: t("offline-suggestions-heading", {
-        defaultValue: "Smart travel hints",
-      }),
-      dismissLabel: t("offline-suggestion-dismiss", {
-        defaultValue: "Dismiss",
-      }),
-    } as const;
-  }, [suggestions.length, t]);
-
-  const dialogCopy = useMemo(() => {
-    if (!dialogOpen) {
-      return null;
-    }
-    return {
-      title: t("offline-dialog-title", { defaultValue: "Download new area" }),
-      description: t("offline-dialog-description", {
-        defaultValue:
-          "Sync maps for offline access. Search for a city or drop a pin to select a custom region.",
-      }),
-      searchPlaceholder: t("offline-dialog-search-placeholder", {
-        defaultValue: "Search cities or regions",
-      }),
-      cancelLabel: t("offline-dialog-cancel", { defaultValue: "Cancel" }),
-      previewLabel: t("offline-dialog-preview", {
-        defaultValue: "Preview download",
-      }),
-    } as const;
-  }, [dialogOpen, t]);
-
-  const { bottomNavAriaLabel, headerTitle, headerSubtitle, backLabel, addAreaLabel } =
-    navigationCopy;
-  const {
-    heading: storageHeading,
-    subtitle: storageSubtitle,
-    usedLabel: storageUsedLabel,
-    usedDescription: storageUsedDescription,
-    mapsLabel: storageMapsLabel,
-    availableLabel: storageAvailableLabel,
-  } = storageCopy;
-  const {
-    downloadsHeading,
-    downloadsDescription,
-    manageLabel,
-    doneLabel,
-    statusCompleteLabel,
-    statusUpdatingLabel,
-    statusDownloadingLabel,
-    undoDescription,
-    undoButtonLabel,
-    autoHeading,
-  } = downloadsCopy;
 
   const percentFormatter = useMemo(
     () =>
@@ -255,6 +121,23 @@ export function OfflineScreen(): JSX.Element {
     [i18n.language],
   );
 
+  const localisation = useOfflineLocalisations({
+    storageUsedFormatted,
+    storageTotalFormatted,
+    storageAutoDeleteDays,
+    suggestionsLength: suggestions.length,
+    dialogOpen,
+  });
+
+  const {
+    navigationCopy,
+    storageCopy,
+    downloadsCopy,
+    suggestionsCopy,
+    dialogCopy,
+    undoDescriptionDefault,
+  } = localisation;
+
   const formatAreaCopy = (area: OfflineMapArea) => {
     const localization = pickLocalization(area.localizations, i18n.language);
     const sizeLabel = formatStorageLabel(area.sizeBytes);
@@ -267,9 +150,9 @@ export function OfflineScreen(): JSX.Element {
   };
 
   const statusLabels: DownloadStatusLabels = {
-    statusCompleteLabel,
-    statusUpdatingLabel,
-    statusDownloadingLabel,
+    statusCompleteLabel: downloadsCopy.statusCompleteLabel,
+    statusUpdatingLabel: downloadsCopy.statusUpdatingLabel,
+    statusDownloadingLabel: downloadsCopy.statusDownloadingLabel,
   };
 
   const handleDeleteDownload = (downloadId: string) => {
@@ -298,12 +181,12 @@ export function OfflineScreen(): JSX.Element {
       <Dialog.Root open={dialogOpen} onOpenChange={setDialogOpen}>
         <div className="screen-stack">
           <AppHeader
-            title={headerTitle}
-            subtitle={headerSubtitle}
+            title={navigationCopy.headerTitle}
+            subtitle={navigationCopy.headerSubtitle}
             leading={
               <button
                 type="button"
-                aria-label={backLabel}
+                aria-label={navigationCopy.backLabel}
                 className="header-nav-button"
                 onClick={() => navigate({ to: "/map/quick" })}
               >
@@ -312,7 +195,11 @@ export function OfflineScreen(): JSX.Element {
             }
             trailing={
               <Dialog.Trigger asChild>
-                <button type="button" aria-label={addAreaLabel} className="header-icon-button">
+                <button
+                  type="button"
+                  aria-label={navigationCopy.addAreaLabel}
+                  className="header-icon-button"
+                >
                   <Icon token="{icon.action.add}" aria-hidden className="h-5 w-5" />
                 </button>
               </Dialog.Trigger>
@@ -320,85 +207,32 @@ export function OfflineScreen(): JSX.Element {
           />
 
           <main className="screen-scroll space-y-6 pt-6">
-            <section className="offline-overview__panel">
-              <div className="mb-4 flex items-center gap-3">
-                <Icon token="{icon.action.download}" className="text-accent" aria-hidden />
-                <div>
-                  <p className="text-sm font-medium text-base-content">{storageHeading}</p>
-                  <OfflineDownloadMeta>{storageSubtitle}</OfflineDownloadMeta>
-                </div>
-              </div>
-              <div className="space-y-3">
-                <div>
-                  <div className="split-row">
-                    <OfflineDownloadMeta as="span">{storageUsedLabel}</OfflineDownloadMeta>
-                    <OfflineDownloadMeta as="span" className="font-semibold text-base-content">
-                      {storageUsedDescription}
-                    </OfflineDownloadMeta>
-                  </div>
-                  <div className="h-2 w-full rounded-full bg-base-300/60">
-                    <div className="h-2 w-[35%] rounded-full bg-accent" />
-                  </div>
-                </div>
-                <div className="flex items-center gap-3 text-xs text-base-content/60">
-                  <span className="flex items-center gap-1">
-                    <span className="block h-2 w-2 rounded-full bg-accent" />
-                    {storageMapsLabel}
-                  </span>
-                  <span className="flex items-center gap-1">
-                    <span className="block h-2 w-2 rounded-full bg-base-300/80" />
-                    {storageAvailableLabel}
-                  </span>
-                </div>
-              </div>
-            </section>
+            <OfflineStorageOverview
+              storageHeading={storageCopy.heading}
+              storageSubtitle={storageCopy.subtitle}
+              storageUsedLabel={storageCopy.usedLabel}
+              storageUsedDescription={storageCopy.usedDescription}
+              storageMapsLabel={storageCopy.mapsLabel}
+              storageAvailableLabel={storageCopy.availableLabel}
+              MetaComponent={OfflineDownloadMeta}
+            />
 
-            {suggestions.length > 0 && suggestionsCopy ? (
+            {suggestionsCopy ? (
               <section className="space-y-3">
                 <h2 className="text-base font-semibold text-base-content">
                   {suggestionsCopy.heading}
                 </h2>
-                {suggestions.map((suggestion) => {
-                  const suggestionCopy = pickLocalization(suggestion.localizations, i18n.language);
-                  const ctaCopy = pickLocalization(suggestion.ctaLocalizations, i18n.language);
-                  return (
-                    <article
-                      key={suggestion.id}
-                      className={`rounded-2xl border border-base-300/60 bg-gradient-to-r ${suggestion.accentClass} p-4 shadow-lg`}
-                    >
-                      <div className="flex items-start gap-3 text-base-100">
-                        <Icon
-                          token={suggestion.iconToken}
-                          className={`text-xl ${suggestion.iconClassName ?? ""}`.trim()}
-                          aria-hidden
-                        />
-                        <div className="flex-1">
-                          <h3 className="text-base font-semibold text-base-100">
-                            {suggestionCopy.name}
-                          </h3>
-                          <p className="mt-1 text-sm text-base-100/80">
-                            {suggestionCopy.description}
-                          </p>
-                          <div className="mt-3 flex flex-wrap gap-2">
-                            <Button size="sm">{ctaCopy.name}</Button>
-                            <Button
-                              size="sm"
-                              variant="ghost"
-                              className="border-white/40 text-base-100 hover:bg-white/10"
-                              onClick={() =>
-                                setSuggestions((prev) =>
-                                  prev.filter((item) => item.id !== suggestion.id),
-                                )
-                              }
-                            >
-                              {suggestionsCopy.dismissLabel}
-                            </Button>
-                          </div>
-                        </div>
-                      </div>
-                    </article>
-                  );
-                })}
+                {suggestions.map((suggestion) => (
+                  <OfflineSuggestionCard
+                    key={suggestion.id}
+                    suggestion={suggestion}
+                    dismissLabel={suggestionsCopy.dismissLabel}
+                    i18nLanguage={i18n.language}
+                    onDismiss={() =>
+                      setSuggestions((prev) => prev.filter((item) => item.id !== suggestion.id))
+                    }
+                  />
+                ))}
               </section>
             ) : null}
 
@@ -409,9 +243,9 @@ export function OfflineScreen(): JSX.Element {
                     id="downloaded-areas-heading"
                     className="text-base font-semibold text-base-content"
                   >
-                    {downloadsHeading}
+                    {downloadsCopy.downloadsHeading}
                   </h2>
-                  <OfflineDownloadMeta>{downloadsDescription}</OfflineDownloadMeta>
+                  <OfflineDownloadMeta>{downloadsCopy.downloadsDescription}</OfflineDownloadMeta>
                 </div>
                 <Button
                   size="sm"
@@ -428,144 +262,45 @@ export function OfflineScreen(): JSX.Element {
                     })
                   }
                 >
-                  {isManaging ? doneLabel : manageLabel}
+                  {isManaging ? downloadsCopy.doneLabel : downloadsCopy.manageLabel}
                 </Button>
               </header>
 
               <div className="space-y-3">
-                {downloads.map((entry) => {
-                  const area = entry.area;
-                  const { localization, sizeLabel, updatedLabel } = formatAreaCopy(area);
-                  const progressPercent = percentFormatter.format(area.progress);
+                {downloads.map((entry) => (
+                  <OfflineDownloadCard
+                    key={entry.kind === "undo" ? `${entry.area.id}-undo` : entry.area.id}
+                    entry={entry}
+                    isManaging={isManaging}
+                    statusLabels={statusLabels}
+                    formatAreaCopy={formatAreaCopy}
+                    percentFormatter={percentFormatter}
+                    undoDescription={downloadsCopy.undoDescription}
+                    undoDescriptionDefault={undoDescriptionDefault}
+                    undoButtonLabel={downloadsCopy.undoButtonLabel}
+                    MetaComponent={OfflineDownloadMeta}
+                    renderStatusBadge={renderStatusBadge}
+                    onDelete={handleDeleteDownload}
+                    onUndo={handleUndoDownload}
+                    t={t}
+                  />
+                ))}
+              </div>
+            </section>
 
-                  return entry.kind === "download" ? (
-                    <article
-                      key={area.id}
-                      data-testid="offline-download-card"
-                      className="offline-download__card"
-                      aria-labelledby={`${area.id}-title`}
-                    >
-                      {isManaging ? (
-                        <button
-                          type="button"
-                          data-testid="offline-delete-button"
-                          aria-label={t("offline-downloads-delete-aria", {
-                            title: localization.name,
-                            defaultValue: `Delete ${localization.name}`,
-                          })}
-                          className="offline-download__dismiss"
-                          onClick={() => handleDeleteDownload(area.id)}
-                        >
-                          <Icon token="{icon.action.remove}" className="text-lg" aria-hidden />
-                        </button>
-                      ) : null}
-                      <img
-                        src={area.image.url}
-                        alt={area.image.alt}
-                        className="h-16 w-16 flex-shrink-0 rounded-xl object-cover"
-                      />
-                      <div className="flex-1">
-                        <div className="split-row">
-                          <div>
-                            <h3 id={`${area.id}-title`} className="font-semibold text-base-content">
-                              {localization.name}
-                            </h3>
-                            <OfflineDownloadMeta>
-                              {updatedLabel} • {sizeLabel}
-                            </OfflineDownloadMeta>
-                          </div>
-                          {renderStatusBadge(area.status, statusLabels)}
-                        </div>
-                        <div className="mt-2 flex items-center gap-3">
-                          <div className="h-1.5 flex-1 rounded-full bg-base-300/60">
-                            <div
-                              className={`h-1.5 rounded-full ${area.status === "downloading" ? "bg-amber-400" : "bg-accent"}`}
-                              style={{
-                                width: `${Math.round(area.progress * 100)}%`,
-                              }}
-                            />
-                          </div>
-                          <OfflineDownloadMeta as="span">{progressPercent}</OfflineDownloadMeta>
-                        </div>
-                      </div>
-                    </article>
-                  ) : (
-                    <article
-                      key={`${area.id}-undo`}
-                      data-testid="offline-undo-card"
-                      className="offline-download__undo"
-                      aria-label={t("offline-downloads-undo-aria", {
-                        title: localization.name,
-                        description: undoDescriptionDefault,
-                        defaultValue: "{{title}} deleted. {{description}}",
-                      })}
-                    >
-                      <div>
-                        <p className="font-semibold">
-                          {t("offline-downloads-undo-title", {
-                            title: localization.name,
-                            defaultValue: `${localization.name} deleted`,
-                          })}
-                        </p>
-                        <OfflineDownloadMeta>{undoDescription}</OfflineDownloadMeta>
-                      </div>
-                      <button
-                        type="button"
-                        className="btn btn-sm btn-ghost"
-                        onClick={() => handleUndoDownload(area.id)}
-                        data-testid="offline-undo-button"
-                      >
-                        {undoButtonLabel}
-                      </button>
-                    </article>
-                  );
-                })}
-              </div>
-            </section>
-            <section className="space-y-4">
-              <header className="flex items-center gap-3">
-                <Icon token="{icon.action.settings}" className="text-accent" aria-hidden />
-                <h2 className="text-base font-semibold text-base-content">{autoHeading}</h2>
-              </header>
-              <div className="space-y-4">
-                {autoManagementOptions.map((option) => {
-                  const checked = autoSettings[option.id] ?? option.defaultEnabled;
-                  const optionLocalization = pickLocalization(option.localizations, i18n.language);
-                  const retentionLabel =
-                    option.retentionDays != null
-                      ? t("offline-auto-option-retention", {
-                          count: option.retentionDays,
-                          days: integerFormatter.format(option.retentionDays),
-                          defaultValue: `${integerFormatter.format(option.retentionDays)} days`,
-                        })
-                      : null;
-                  const optionDescription =
-                    optionLocalization.description ??
-                    (retentionLabel
-                      ? t("offline-auto-option-auto-delete-description", {
-                          days: retentionLabel,
-                          defaultValue: `Remove maps after ${retentionLabel}`,
-                        })
-                      : "");
-                  return (
-                    <PreferenceToggleCard
-                      key={option.id}
-                      id={`auto-management-${option.id}`}
-                      iconToken={option.iconToken}
-                      iconClassName={option.iconClassName}
-                      title={optionLocalization.name}
-                      description={optionDescription}
-                      isChecked={Boolean(checked)}
-                      onCheckedChange={(value) => handleToggleAutoSetting(option.id, value)}
-                    />
-                  );
-                })}
-              </div>
-            </section>
+            <OfflineAutoManagement
+              autoHeading={downloadsCopy.autoHeading}
+              autoManagementOptions={autoManagementOptions}
+              autoSettings={autoSettings}
+              onToggle={handleToggleAutoSetting}
+              integerFormatter={integerFormatter}
+              i18nLanguage={i18n.language}
+              t={t}
+            />
           </main>
 
           <AppBottomNavigation
-            aria-label={bottomNavAriaLabel}
+            aria-label={navigationCopy.bottomNavAriaLabel}
             items={bottomNavigation.map((item) => ({
               ...item,
               label: t(`nav-${item.id}-label`, { defaultValue: item.label }),
@@ -574,31 +309,7 @@ export function OfflineScreen(): JSX.Element {
           />
         </div>
 
-        <Dialog.Portal>
-          <Dialog.Overlay className="fixed inset-0 bg-black/60" />
-          <Dialog.Content className="dialog-surface">
-            <Dialog.Title className="text-lg font-semibold text-base-content">
-              {dialogCopy?.title ?? "Download new area"}
-            </Dialog.Title>
-            <Dialog.Description className="text-sm text-base-content/70">
-              {dialogCopy?.description ??
-                "Sync maps for offline access. Search for a city or drop a pin to select a custom region."}
-            </Dialog.Description>
-            <input
-              type="search"
-              placeholder={dialogCopy?.searchPlaceholder ?? "Search cities or regions"}
-              className="offline-search__input"
-            />
-            <div className="flex justify-end gap-2">
-              <Dialog.Close asChild>
-                <Button size="sm" variant="ghost">
-                  {dialogCopy?.cancelLabel ?? "Cancel"}
-                </Button>
-              </Dialog.Close>
-              <Button size="sm">{dialogCopy?.previewLabel ?? "Preview download"}</Button>
-            </div>
-          </Dialog.Content>
-        </Dialog.Portal>
+        <OfflineDownloadDialog dialogCopy={dialogCopy} />
       </Dialog.Root>
     </MobileShell>
   );

--- a/src/app/lib/relative-time.ts
+++ b/src/app/lib/relative-time.ts
@@ -1,0 +1,53 @@
+/** @file Small helper to format past/future instants as relative time labels. */
+
+type SupportedUnit = "day" | "hour" | "minute" | "second";
+
+const MILLISECONDS_PER_SECOND = 1000;
+const SECONDS_PER_MINUTE = 60;
+const MINUTES_PER_HOUR = 60;
+const HOURS_PER_DAY = 24;
+
+const UNIT_THRESHOLDS: Array<{ unit: SupportedUnit; seconds: number }> = [
+  { unit: "day", seconds: HOURS_PER_DAY * MINUTES_PER_HOUR * SECONDS_PER_MINUTE },
+  { unit: "hour", seconds: MINUTES_PER_HOUR * SECONDS_PER_MINUTE },
+  { unit: "minute", seconds: SECONDS_PER_MINUTE },
+  { unit: "second", seconds: 1 },
+];
+
+const normaliseInstant = (input: Date | number | string): number => {
+  if (input instanceof Date) {
+    return input.getTime();
+  }
+  if (typeof input === "number") {
+    return input;
+  }
+  return new Date(input).getTime();
+};
+
+/**
+ * Format a timestamp relative to `now`, favouring the largest meaningful unit.
+ *
+ * @example
+ * formatRelativeTime(Date.now() - 36_000, "en-GB"); // "10 hours ago"
+ */
+export const formatRelativeTime = (
+  input: Date | number | string,
+  locale: string,
+  now: number = Date.now(),
+): string => {
+  const targetMs = normaliseInstant(input);
+  if (!Number.isFinite(targetMs)) return "";
+
+  const deltaSeconds = Math.round((targetMs - now) / MILLISECONDS_PER_SECOND);
+  const formatter = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
+
+  const magnitude = Math.abs(deltaSeconds);
+  for (const { unit, seconds } of UNIT_THRESHOLDS) {
+    if (magnitude >= seconds || unit === "second") {
+      const value = Math.round(deltaSeconds / seconds);
+      return formatter.format(value, unit);
+    }
+  }
+
+  return formatter.format(0, "second");
+};

--- a/src/app/lib/relative-time.ts
+++ b/src/app/lib/relative-time.ts
@@ -49,5 +49,7 @@ export const formatRelativeTime = (
     }
   }
 
+  // Unreachable: loop always returns at "second" threshold, but TypeScript
+  // requires a return path. Kept as a defensive fallback.
   return formatter.format(0, "second");
 };

--- a/src/app/lib/relative-time.ts
+++ b/src/app/lib/relative-time.ts
@@ -1,9 +1,10 @@
 /** @file Small helper to format past/future instants as relative time labels. */
 
+import { SECONDS_PER_MINUTE } from "../units/unit-system";
+
 type SupportedUnit = "day" | "hour" | "minute" | "second";
 
 const MILLISECONDS_PER_SECOND = 1000;
-const SECONDS_PER_MINUTE = 60;
 const MINUTES_PER_HOUR = 60;
 const HOURS_PER_DAY = 24;
 
@@ -28,7 +29,7 @@ const normaliseInstant = (input: Date | number | string): number => {
  * Format a timestamp relative to `now`, favouring the largest meaningful unit.
  *
  * @example
- * formatRelativeTime(Date.now() - 36_000, "en-GB"); // "10 hours ago"
+ * formatRelativeTime(Date.now() - 36_000_000, "en-GB"); // "10 hours ago"
  */
 export const formatRelativeTime = (
   input: Date | number | string,
@@ -49,7 +50,7 @@ export const formatRelativeTime = (
     }
   }
 
-  // Unreachable: loop always returns at "second" threshold, but TypeScript
-  // requires a return path. Kept as a defensive fallback.
-  return formatter.format(0, "second");
+  // Satisfy TypeScript's control flow analysis. The loop always returns at the
+  // "second" threshold, making this path unreachable at runtime.
+  throw new Error("Unreachable: UNIT_THRESHOLDS must include 'second'");
 };

--- a/src/app/lib/relative-time.ts
+++ b/src/app/lib/relative-time.ts
@@ -28,13 +28,16 @@ const normaliseInstant = (input: Date | number | string): number => {
 /**
  * Format a timestamp relative to `now`, favouring the largest meaningful unit.
  *
+ * Returns an empty string when `input` cannot be parsed as a finite timestamp.
+ *
  * @example
- * formatRelativeTime(Date.now() - 36_000_000, "en-GB"); // "10 hours ago"
+ * import { getNow } from "./time";
+ * formatRelativeTime(getNow() - 36_000_000, "en-GB", getNow()); // "10 hours ago"
  */
 export const formatRelativeTime = (
   input: Date | number | string,
   locale: string,
-  now: number = Date.now(),
+  now: number,
 ): string => {
   const targetMs = normaliseInstant(input);
   if (!Number.isFinite(targetMs)) return "";

--- a/src/app/lib/time.ts
+++ b/src/app/lib/time.ts
@@ -1,0 +1,13 @@
+/** @file Centralised time adapter for testability and consistency. */
+
+/**
+ * Return the current Unix timestamp in milliseconds.
+ *
+ * Centralising `Date.now()` calls enables deterministic testing and ensures
+ * consistent time sources across the application.
+ *
+ * @example
+ * const now = getNow();
+ * formatRelativeTime(pastTimestamp, "en-GB", now);
+ */
+export const getNow = (): number => Date.now();

--- a/tests/e2e/accessibility-snapshots.pw.ts-snapshots/explore-aria-tree-chromium-linux.json
+++ b/tests/e2e/accessibility-snapshots.pw.ts-snapshots/explore-aria-tree-chromium-linux.json
@@ -85,7 +85,7 @@
                                         "name": "",
                                         "children": [
                                           {
-                                            "role": "button",
+                                            "role": "link",
                                             "name": "Filter walks"
                                           }
                                         ]

--- a/tests/point-of-interest-list.a11y.test.tsx
+++ b/tests/point-of-interest-list.a11y.test.tsx
@@ -33,7 +33,9 @@ describe("PointOfInterestList accessibility", () => {
       expect(await axe(container)).toHaveNoViolations();
 
       const trigger = screen.getByRole("button", { name: new RegExp(poiCopy.name, "i") });
-      expect(within(trigger).getByText(poiCopy.description ?? "")).toBeInTheDocument();
+      if (poiCopy.description) {
+        expect(within(trigger).getByText(poiCopy.description)).toBeInTheDocument();
+      }
       if (ratingLabel) {
         expect(within(trigger).getByText(ratingLabel)).toBeInTheDocument();
       }
@@ -46,7 +48,9 @@ describe("PointOfInterestList accessibility", () => {
 
       const dialog = await screen.findByRole("dialog", { name: poiCopy.name });
       expect(dialog).toBeInTheDocument();
-      expect(within(dialog).getByText(poiCopy.description ?? "")).toBeInTheDocument();
+      if (poiCopy.description) {
+        expect(within(dialog).getByText(poiCopy.description)).toBeInTheDocument();
+      }
       expect(await axe(document.body)).toHaveNoViolations();
 
       await userEvent.click(screen.getByRole("button", { name: /close/i }));

--- a/tests/point-of-interest-list.a11y.test.tsx
+++ b/tests/point-of-interest-list.a11y.test.tsx
@@ -4,6 +4,9 @@ import { describe, expect, it } from "vitest";
 
 import { PointOfInterestList } from "../src/app/components/point-of-interest-list";
 import { waterfrontDiscoveryRoute } from "../src/app/data/map";
+import { getTagDescriptor } from "../src/app/data/registries/tags";
+import { pickLocalization } from "../src/app/domain/entities/localization";
+import { i18nReady, withI18nLanguage } from "./helpers/i18nTestHelpers";
 import { axe } from "./utils/axe";
 import { renderWithProviders } from "./utils/render-with-providers";
 
@@ -12,27 +15,41 @@ describe("PointOfInterestList accessibility", () => {
   if (!samplePoi) {
     throw new Error("Expected at least one point of interest for accessibility tests");
   }
+  const poiCopy = pickLocalization(samplePoi.localizations, "en-GB");
+  const category = getTagDescriptor(samplePoi.categoryId, "en-GB");
+  const ratingLabel =
+    typeof samplePoi.rating === "number"
+      ? new Intl.NumberFormat("en-GB", {
+          minimumFractionDigits: 1,
+          maximumFractionDigits: 1,
+        }).format(samplePoi.rating)
+      : undefined;
 
   it("exposes accessible trigger buttons and modal content", async () => {
-    const { container } = renderWithProviders(<PointOfInterestList points={[samplePoi]} />);
+    await i18nReady;
+    await withI18nLanguage("en-GB", async () => {
+      const { container } = renderWithProviders(<PointOfInterestList points={[samplePoi]} />);
 
-    expect(await axe(container)).toHaveNoViolations();
+      expect(await axe(container)).toHaveNoViolations();
 
-    const trigger = screen.getByRole("button", { name: new RegExp(samplePoi.name, "i") });
-    expect(within(trigger).getByText(samplePoi.description)).toBeInTheDocument();
-    if (samplePoi.rating) {
-      expect(within(trigger).getByText(samplePoi.rating.toFixed(1))).toBeInTheDocument();
-    }
-    const highlightIcon = within(trigger).getByRole("img", { name: samplePoi.categoryLabel });
-    expect(highlightIcon).toBeInTheDocument();
+      const trigger = screen.getByRole("button", { name: new RegExp(poiCopy.name, "i") });
+      expect(within(trigger).getByText(poiCopy.description ?? "")).toBeInTheDocument();
+      if (ratingLabel) {
+        expect(within(trigger).getByText(ratingLabel)).toBeInTheDocument();
+      }
+      const highlightIcon = within(trigger).getByRole("img", {
+        name: category?.localization.name ?? samplePoi.categoryId,
+      });
+      expect(highlightIcon).toBeInTheDocument();
 
-    await userEvent.click(trigger);
+      await userEvent.click(trigger);
 
-    const dialog = await screen.findByRole("dialog", { name: samplePoi.name });
-    expect(dialog).toBeInTheDocument();
-    expect(within(dialog).getByText(samplePoi.description)).toBeInTheDocument();
-    expect(await axe(document.body)).toHaveNoViolations();
+      const dialog = await screen.findByRole("dialog", { name: poiCopy.name });
+      expect(dialog).toBeInTheDocument();
+      expect(within(dialog).getByText(poiCopy.description ?? "")).toBeInTheDocument();
+      expect(await axe(document.body)).toHaveNoViolations();
 
-    await userEvent.click(screen.getByRole("button", { name: /close/i }));
+      await userEvent.click(screen.getByRole("button", { name: /close/i }));
+    });
   });
 });

--- a/tokens/src/tokens.json
+++ b/tokens/src/tokens.json
@@ -87,7 +87,7 @@
       "back": { "value": "IconArrowLeft", "description": "Back navigation affordance" },
       "forward": { "value": "IconArrowRight", "description": "Forward navigation affordance" },
       "chevronDown": { "value": "IconChevronDown", "description": "Disclosure indicator" },
-      "download": { "value": "IconDownload", "description": "Download action in offline navigation" }
+      "download": { "value": "IconDownload", "description": "Add area button in offline manager header" }
     },
     "action": {
       "help": { "value": "IconHelp", "description": "Help indicator" },

--- a/tokens/src/tokens.json
+++ b/tokens/src/tokens.json
@@ -86,7 +86,8 @@
       "profile": { "value": "IconUser", "description": "Bottom nav: Profile" },
       "back": { "value": "IconArrowLeft", "description": "Back navigation affordance" },
       "forward": { "value": "IconArrowRight", "description": "Forward navigation affordance" },
-      "chevronDown": { "value": "IconChevronDown", "description": "Disclosure indicator" }
+      "chevronDown": { "value": "IconChevronDown", "description": "Disclosure indicator" },
+      "download": { "value": "IconDownload", "description": "Download navigation action" }
     },
     "action": {
       "help": { "value": "IconHelp", "description": "Help indicator" },

--- a/tokens/src/tokens.json
+++ b/tokens/src/tokens.json
@@ -87,7 +87,7 @@
       "back": { "value": "IconArrowLeft", "description": "Back navigation affordance" },
       "forward": { "value": "IconArrowRight", "description": "Forward navigation affordance" },
       "chevronDown": { "value": "IconChevronDown", "description": "Disclosure indicator" },
-      "download": { "value": "IconDownload", "description": "Download navigation action" }
+      "download": { "value": "IconDownload", "description": "Download action in offline navigation" }
     },
     "action": {
       "help": { "value": "IconHelp", "description": "Help indicator" },


### PR DESCRIPTION
## Summary by Sourcery

Localize offline maps, routes, and POIs using shared card-style data models and registries, and update offline UI and tests to consume the new structures.

New Features:
- Add relative time formatting helper for timestamps on offline map areas and saved routes.

Enhancements:
- Reshape route, point-of-interest, and offline map area fixtures to use shared localization maps, image assets, difficulty and tag registries.
- Update the offline screen to render localized suggestions, map areas, sizes, progress, and auto-management options with locale-aware number and time formatting.
- Align itinerary and saved-route views with the card architecture by reading localized route copy, tag-based highlights, and note entities.
- Enhance point-of-interest list and dialogs to resolve localized copy, category metadata, tags, ratings, and opening hours via registries and i18n.

Documentation:
- Extend card-architecture documentation to record the rollout status for offline suggestions and downloads.

Tests:
- Adjust unit and accessibility tests to work with localized entities, tag registries, and the new offline data model.