### PR TITLE
Re-enable the semantic lint gate in CI

### DIFF
--- a/.github/workflows/semantic-lint.yml
+++ b/.github/workflows/semantic-lint.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: "latest"
+      # uv provides uvx, which `bun semantic` uses to run semgrep.
+      - uses: astral-sh/setup-uv@v7
       - run: bun install --frozen-lockfile
-      # Temporarily disabled until the semantic-class migration is complete.
-      # - run: bun semantic
+      - run: bun semantic

--- a/.github/workflows/semantic-lint.yml
+++ b/.github/workflows/semantic-lint.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           bun-version: "latest"
       # uv provides uvx, which `bun semantic` uses to run semgrep.
-      - uses: astral-sh/setup-uv@v7
+      # Pinned to astral-sh/setup-uv v7.
+      - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9
       - run: bun install --frozen-lockfile
       - run: bun semantic

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist/
 tmp/
 .tmp/
 .serena/
+.memdb/
 
 tokens/node_modules/
 tokens/dist/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: check-fmt lint typecheck test
+
+check-fmt:
+	bunx biome format --write src tests tools package.json biome.jsonc bunfig.toml
+
+lint:
+	bun lint
+	actionlint .github/workflows/semantic-lint.yml
+
+typecheck:
+	bun check:types
+
+test:
+	bun test

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: check-fmt lint typecheck test
 
 check-fmt:
-	bunx biome format --write src tests tools package.json biome.jsonc bunfig.toml
+	bunx biome format --write src tests tools docs/developers-guide.md package.json biome.jsonc bunfig.toml
 
 lint:
 	bun lint

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1,0 +1,61 @@
+# Developers guide
+
+This guide records the local development commands and Continuous Integration
+(CI) tooling that contributors should have available before working on the
+application.
+
+## Local prerequisites
+
+Install the standard project toolchain before running gates locally:
+
+- [Bun](https://bun.sh/) for package installation, scripts, tests, and Vite
+  tooling.
+- [uv](https://docs.astral.sh/uv/) for `uvx`, which runs Semgrep inside the
+  semantic lint suite.
+- [actionlint](https://github.com/rhysd/actionlint) for validating GitHub
+  Actions workflow syntax.
+- [mbake](https://github.com/jeluard/mbake) for validating Makefile syntax
+  when Makefile targets change.
+
+After cloning, install JavaScript dependencies with:
+
+```bash
+bun install --frozen-lockfile
+```
+
+## Makefile gates
+
+The repository exposes the review and CI-adjacent checks through Makefile
+targets. Prefer these targets over invoking the underlying commands directly
+when validating a change.
+
+- `make check-fmt` formats source, tests, tools, root config, and this
+  developer guide with Biome.
+- `make lint` runs `bun lint` and validates
+  `.github/workflows/semantic-lint.yml` with `actionlint`.
+- `make typecheck` runs the TypeScript compiler with `bun check:types`.
+- `make test` runs the Bun unit and behavioural test suite.
+
+When changing the Makefile itself, validate it with:
+
+```bash
+mbake validate Makefile
+```
+
+## Semantic lint tooling
+
+The semantic lint gate is run locally with:
+
+```bash
+bun semantic
+```
+
+This command executes the semantic suite: Biome checks, class-list length and
+near-duplicate checks, Semgrep semantic rules through `uvx`, and Stylelint for
+CSS. Because Semgrep is invoked through `uvx`, local development environments
+and CI runners must provide `uv`.
+
+The GitHub Actions workflow that runs this gate installs Bun and uv before
+running `bun semantic`. Keep third-party workflow actions pinned to immutable
+commit SHAs, and run `make lint` after workflow changes so `actionlint`
+validates the edited YAML.

--- a/src/app/data/explore.routes.ts
+++ b/src/app/data/explore.routes.ts
@@ -249,5 +249,5 @@ export const curatedRouteMaps: Record<string, string> = {
   "after-dark": walkRouteMap3,
 };
 
-export type { Route, RouteCollection, CommunityPick, TrendingRouteHighlight };
+export type { CommunityPick, Route, RouteCollection, TrendingRouteHighlight };
 export type ExploreRouteBadgeId = BadgeId;

--- a/src/app/features/explore/explore-sections.tsx
+++ b/src/app/features/explore/explore-sections.tsx
@@ -331,5 +331,5 @@ export function CuratedCollectionsList({
   );
 }
 
-export { CommunityPickPanel, TrendingRoutesList };
 export type { TrendingRouteCard } from "./explore-trending";
+export { CommunityPickPanel, TrendingRoutesList };

--- a/tests/fluent-quick-walk-duration.test.ts
+++ b/tests/fluent-quick-walk-duration.test.ts
@@ -40,7 +40,7 @@ describe("quick walk duration Fluent message", () => {
     const bundle = new FluentBundle("it");
     bundle.addResource(new FluentResource(source));
     const message = bundle.getMessage("quick-walk-duration-format");
-    if (!message || !message.value) throw new Error("missing message");
+    if (!message?.value) throw new Error("missing message");
     const pattern = message.value;
     expect(() => bundle.formatPattern(pattern)).toThrow();
   });

--- a/tests/quick-map-fragment.test.tsx
+++ b/tests/quick-map-fragment.test.tsx
@@ -7,6 +7,7 @@ import { DisplayModeProvider } from "../src/app/providers/display-mode-provider"
 import { ThemeProvider } from "../src/app/providers/theme-provider";
 import { AppRoutes, createAppRouter } from "../src/app/routes/app-routes";
 import { UnitPreferencesProvider } from "../src/app/units/unit-preferences-provider";
+import { resetLanguage } from "./helpers/i18nTestHelpers";
 
 async function renderRoute(path: string) {
   window.history.replaceState(null, "", path);
@@ -51,8 +52,16 @@ describe("quick map hash fragments", () => {
     host = null;
   };
 
-  beforeEach(() => cleanup());
-  afterEach(() => cleanup());
+  beforeEach(async () => {
+    cleanup();
+    window.localStorage.setItem("i18nextLng", "en-GB");
+    await resetLanguage();
+  });
+
+  afterEach(async () => {
+    cleanup();
+    await resetLanguage();
+  });
 
   it("activates the stops tab when loading #stops", async () => {
     ({ root, host } = await renderRoute("/map/quick#stops"));

--- a/tests/quick-map-fragment.test.tsx
+++ b/tests/quick-map-fragment.test.tsx
@@ -1,3 +1,11 @@
+/** @file Verifies quick-walk map hash fragments activate the expected tab panels.
+ *
+ * The route renders localized accessible names, so these tests reset i18n to
+ * `en-GB` through `resetLanguage` and the `i18nextLng` storage key before each
+ * render. That keeps the hash-fragment assertions deterministic while still
+ * exercising the production i18n runtime.
+ */
+
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { within } from "@testing-library/dom";
 import React, { act } from "react";


### PR DESCRIPTION
## Summary

This branch restores the semantic lint gate that CI stopped enforcing when the `bun semantic` step was commented out pending the semantic-class migration. The required `lint` check had been passing trivially because it installed dependencies and ran nothing.

The full semantic suite (`biome ci`, class-list length and near-duplicate checks, the semgrep semantic rules, and stylelint) now passes against the current tree, so the step is re-enabled. The branch also installs `uv`, because `semantic:lint` invokes semgrep via `uvx`, which was never installed on the bun-only runner.

Review feedback is addressed by pinning `astral-sh/setup-uv` to the commit currently backing v7, and by adding Makefile gates that include automated workflow validation with `actionlint`.

## Review walkthrough

- [.github/workflows/semantic-lint.yml](https://github.com/leynos/wildside-mockup/blob/fix/reenable-semantic-lint/.github/workflows/semantic-lint.yml) restores `bun semantic`, installs `uv`, and pins `astral-sh/setup-uv` to a full commit SHA.
- `Makefile` adds the requested `check-fmt`, `lint`, `typecheck`, and `test` gates; `make lint` also runs `actionlint` against the semantic-lint workflow.
- Small existing lint and test-determinism issues surfaced by the new gates were fixed so the required checks complete cleanly.

## Validation

- `make check-fmt`: clean
- `make lint`: clean, including `actionlint .github/workflows/semantic-lint.yml`
- `make typecheck`: clean
- `make test`: clean, 201 passing tests
- `mbake validate Makefile`: clean
- `bun semantic`: clean (biome checked 219 files; classlist and near-duplicate checks clean; semgrep 6 rules, 0 findings; stylelint clean)

## Notes

- Semgrep reports scanning only 1 file due to its `--include` pattern behaviour; that matches how the suite runs locally and is unchanged here.

## References

- Lody session: https://lody.ai/leynos/sessions/89a744d1-a314-4e51-b2ad-5376a99bd9ee
